### PR TITLE
Add MapManager: biome random selection and map loading (#11)

### DIFF
--- a/roblox/ServerScriptService/MapManager.server.lua
+++ b/roblox/ServerScriptService/MapManager.server.lua
@@ -1,0 +1,199 @@
+-- MapManager.server.lua
+-- Biome random selection, map model loading/unloading, lighting/skybox swap.
+-- Resolves: Issue #11
+
+local Players             = game:GetService("Players")
+local Lighting            = game:GetService("Lighting")
+local ReplicatedStorage   = game:GetService("ReplicatedStorage")
+local ServerScriptService = game:GetService("ServerScriptService")
+local CollectionService   = game:GetService("CollectionService")
+
+local Constants    = require(ReplicatedStorage.Shared.Constants)
+local RemoteEvents = require(ReplicatedStorage.RemoteEvents)
+local BiomeConfig  = require(ServerScriptService.Modules.BiomeConfig)
+local GameManager  = require(ServerScriptService.GameManager)
+
+-- ─── Map folder convention ────────────────────────────────────────────────────
+-- Each map lives under workspace.Maps.<BiomeName>Map as a Model.
+-- The model is Disabled (invisible) by default; MapManager toggles visibility.
+-- Studio maps tagged with CollectionService tags: MudZone, UpdraftZone, etc.
+
+local MAP_FOLDER_NAME = "Maps"
+
+local _currentBiome   = nil
+local _mapsFolder     = nil
+
+-- ─── Lighting presets ─────────────────────────────────────────────────────────
+
+local LIGHTING_PRESETS = {
+	FOREST = {
+		Ambient          = Color3.fromRGB(80, 100, 60),
+		OutdoorAmbient   = Color3.fromRGB(100, 130, 80),
+		Brightness       = 2.5,
+		ClockTime        = 12,
+		FogEnd           = 800,
+		FogColor         = Color3.fromRGB(180, 200, 150),
+	},
+	OCEAN = {
+		Ambient          = Color3.fromRGB(60, 90, 130),
+		OutdoorAmbient   = Color3.fromRGB(80, 130, 180),
+		Brightness       = 3.0,
+		ClockTime        = 14,
+		FogEnd           = 1200,
+		FogColor         = Color3.fromRGB(160, 200, 230),
+	},
+	SKY = {
+		Ambient          = Color3.fromRGB(120, 100, 160),
+		OutdoorAmbient   = Color3.fromRGB(160, 140, 200),
+		Brightness       = 2.8,
+		ClockTime        = 10,
+		FogEnd           = 2000,
+		FogColor         = Color3.fromRGB(200, 190, 230),
+	},
+}
+
+local function _applyLighting(biome)
+	local preset = LIGHTING_PRESETS[biome]
+	if not preset then return end
+	for prop, value in pairs(preset) do
+		pcall(function() Lighting[prop] = value end)
+	end
+end
+
+-- ─── Map visibility helpers ───────────────────────────────────────────────────
+
+local function _getMapsFolder()
+	if _mapsFolder then return _mapsFolder end
+	_mapsFolder = workspace:FindFirstChild(MAP_FOLDER_NAME)
+	if not _mapsFolder then
+		-- Create placeholder folder if maps haven't been built yet
+		_mapsFolder = Instance.new("Folder")
+		_mapsFolder.Name   = MAP_FOLDER_NAME
+		_mapsFolder.Parent = workspace
+		warn("[MapManager] No Maps folder found in Workspace — biome maps not built yet (#8 #9 #10)")
+	end
+	return _mapsFolder
+end
+
+local function _hideAllMaps()
+	local folder = _getMapsFolder()
+	for _, child in ipairs(folder:GetChildren()) do
+		if child:IsA("Model") or child:IsA("Folder") then
+			child:SetAttribute("MapVisible", false)
+			-- Hide all descendant BaseParts
+			for _, desc in ipairs(child:GetDescendants()) do
+				if desc:IsA("BasePart") then
+					desc.Transparency = 1
+					desc.CanCollide   = false
+				end
+			end
+		end
+	end
+end
+
+local function _showMap(biome)
+	local folder   = _getMapsFolder()
+	local mapName  = biome:sub(1, 1):upper() .. biome:sub(2):lower() .. "Map"
+	local mapModel = folder:FindFirstChild(mapName)
+
+	if not mapModel then
+		warn(string.format("[MapManager] Map model '%s' not found — build it in Studio (#8 #9 #10)", mapName))
+		return false
+	end
+
+	mapModel:SetAttribute("MapVisible", true)
+	for _, desc in ipairs(mapModel:GetDescendants()) do
+		if desc:IsA("BasePart") then
+			-- Restore transparency to what it was at edit time (stored in attribute)
+			local storedT = desc:GetAttribute("OriginalTransparency")
+			desc.Transparency = storedT ~= nil and storedT or 0
+			desc.CanCollide   = true
+		end
+	end
+	return true
+end
+
+-- ─── Store original transparencies (called once at startup) ──────────────────
+
+local function _cacheTransparencies()
+	local folder = _getMapsFolder()
+	for _, mapModel in ipairs(folder:GetChildren()) do
+		for _, desc in ipairs(mapModel:GetDescendants()) do
+			if desc:IsA("BasePart") then
+				if desc:GetAttribute("OriginalTransparency") == nil then
+					desc:SetAttribute("OriginalTransparency", desc.Transparency)
+				end
+			end
+		end
+	end
+end
+
+-- ─── Biome selection ──────────────────────────────────────────────────────────
+
+local function _selectAndLoadBiome()
+	local biome = BiomeConfig.random()
+	_currentBiome = biome
+
+	_hideAllMaps()
+	local loaded = _showMap(biome)
+	_applyLighting(biome)
+
+	-- Broadcast biome to all clients
+	RemoteEvents.BiomeSelected:FireAllClients(biome)
+
+	if loaded then
+		print(string.format("[MapManager] Loaded biome: %s", biome))
+	else
+		print(string.format("[MapManager] Biome selected: %s (no map model yet)", biome))
+	end
+
+	return biome
+end
+
+-- ─── Phase listener ───────────────────────────────────────────────────────────
+
+GameManager.onPhaseChanged(function(phase, biome)
+	if phase == Constants.PHASES.LOBBY then
+		-- Select biome during lobby so players see the reveal
+		task.delay(5, function()
+			if _currentBiome then return end  -- already selected
+			_selectAndLoadBiome()
+		end)
+
+	elseif phase == Constants.PHASES.FARMING then
+		-- Ensure biome is selected (in case lobby delay hasn't fired yet)
+		if not _currentBiome then
+			_selectAndLoadBiome()
+		end
+
+	elseif phase == Constants.PHASES.RESULTS then
+		-- Reset for next round
+		task.delay(Constants.PHASE_DURATION.RESULTS or 15, function()
+			_currentBiome = nil
+		end)
+	end
+end)
+
+-- ─── Expose current biome to other server modules ────────────────────────────
+
+local MapManager = {}
+
+function MapManager.getCurrentBiome()
+	return _currentBiome
+end
+
+function MapManager.forceSelectBiome(biome)
+	-- Used in testing / admin commands
+	_currentBiome = nil
+	_currentBiome = biome
+	_hideAllMaps()
+	_showMap(biome)
+	_applyLighting(biome)
+	RemoteEvents.BiomeSelected:FireAllClients(biome)
+end
+
+-- ─── Cache transparencies on start ───────────────────────────────────────────
+
+task.defer(_cacheTransparencies)
+
+return MapManager


### PR DESCRIPTION
## Summary
- `MapManager.server.lua`: BiomeConfig.random()으로 바이옴 선택, 선택된 바이옴 맵만 표시
- 조명 프리셋 (Ambient, Fog, ClockTime) 바이옴별 적용
- `BiomeSelected` RemoteEvent로 클라이언트에 바이옴 브로드캐스트
- 맵 모델 없을 때 warn으로 graceful 처리 (Studio 맵 작업 전 테스트 가능)

## Test plan
- [ ] Studio에서 Maps/ForestMap 모델 추가 후 FARMING 페이즈 트리거
- [ ] 세 바이옴 모두 올바른 조명 적용 확인
- [ ] BiomeSelected 클라이언트 수신 → LobbyUI 배지 표시 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)