### PR TITLE
Procedural map builders for FOREST/OCEAN/SKY + Terrain API painter (#8 #9 #10)

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -1,0 +1,514 @@
+-- ForestMapBuilder.server.lua
+-- Procedurally builds the FOREST biome map at runtime:
+--   - Farm area (item scatter zone)
+--   - Race track with mud zones, drift corners, jump ramps, boost pads
+--   - Decorative trees and foliage
+-- Resolves: Issue #8
+
+local CollectionService = game:GetService("CollectionService")
+
+local MapBuilders = {}
+
+-- ─── Colour palette ───────────────────────────────────────────────────────────
+
+local C = {
+	GRASS       = Color3.fromRGB(76,  120, 50),
+	DIRT        = Color3.fromRGB(120, 85,  50),
+	MUD         = Color3.fromRGB(80,  55,  30),
+	TRACK       = Color3.fromRGB(60,  55,  50),
+	TRACK_EDGE  = Color3.fromRGB(240, 240, 240),
+	TREE_TRUNK  = Color3.fromRGB(100, 70,  40),
+	TREE_LEAF   = Color3.fromRGB(55,  130, 45),
+	TREE_LEAF2  = Color3.fromRGB(40,  100, 35),
+	FINISH_LINE = Color3.fromRGB(240, 240, 240),
+	BOOST_PAD   = Color3.fromRGB(255, 200, 40),
+	RAMP        = Color3.fromRGB(160, 130, 80),
+	BARRIER     = Color3.fromRGB(200, 60,  40),
+}
+
+local MAT = {
+	GRASS  = Enum.Material.Grass,
+	DIRT   = Enum.Material.Ground,
+	MUD    = Enum.Material.Ground,
+	TRACK  = Enum.Material.Asphalt,
+	WOOD   = Enum.Material.Wood,
+	LEAVES = Enum.Material.LeafyGrass,
+	METAL  = Enum.Material.Metal,
+	NEON   = Enum.Material.Neon,
+}
+
+-- ─── Part factory ─────────────────────────────────────────────────────────────
+
+local function _part(parent, props)
+	local p = Instance.new("Part")
+	p.Anchored    = true
+	p.CanCollide  = true
+	p.CastShadow  = true
+	for k, v in pairs(props) do
+		pcall(function() p[k] = v end)
+	end
+	p.Parent = parent
+	return p
+end
+
+local function _wedge(parent, props)
+	local p = Instance.new("WedgePart")
+	p.Anchored   = true
+	p.CanCollide = true
+	for k, v in pairs(props) do
+		pcall(function() p[k] = v end)
+	end
+	p.Parent = parent
+	return p
+end
+
+local function _tag(part, tagName)
+	CollectionService:AddTag(part, tagName)
+end
+
+-- ─── Map root ─────────────────────────────────────────────────────────────────
+
+local function _getOrCreateMap()
+	local maps = workspace:FindFirstChild("Maps") or (function()
+		local f = Instance.new("Folder"); f.Name = "Maps"; f.Parent = workspace; return f
+	end)()
+	local existing = maps:FindFirstChild("ForestMap")
+	if existing then existing:Destroy() end
+	local model = Instance.new("Model")
+	model.Name   = "ForestMap"
+	model.Parent = maps
+	return model
+end
+
+-- ─── Ground plane ────────────────────────────────────────────────────────────
+
+local function _buildGround(root)
+	-- Large grass plane
+	_part(root, {
+		Name     = "Ground",
+		Size     = Vector3.new(300, 4, 1400),
+		Position = Vector3.new(0, -2, 0),
+		Color    = C.GRASS,
+		Material = MAT.GRASS,
+	})
+end
+
+-- ─── Farm area (Z = 200 to 500) ──────────────────────────────────────────────
+-- Open field where items scatter. Slightly elevated from track.
+
+local function _buildFarmArea(root)
+	-- Dirt patch
+	_part(root, {
+		Name     = "FarmGround",
+		Size     = Vector3.new(200, 2, 300),
+		Position = Vector3.new(0, 0, 350),
+		Color    = C.DIRT,
+		Material = MAT.DIRT,
+	})
+
+	-- Farm boundary fence (4 sides, simple barriers)
+	local fenceData = {
+		{ Vector3.new(200, 6, 2), Vector3.new(0,   3, 200) },  -- near
+		{ Vector3.new(200, 6, 2), Vector3.new(0,   3, 500) },  -- far
+		{ Vector3.new(2,   6, 302), Vector3.new(-100, 3, 350) },  -- left
+		{ Vector3.new(2,   6, 302), Vector3.new(100,  3, 350) },  -- right
+	}
+	for _, fd in ipairs(fenceData) do
+		local f = _part(root, {
+			Name     = "Fence",
+			Size     = fd[1],
+			Position = fd[2],
+			Color    = C.TREE_TRUNK,
+			Material = MAT.WOOD,
+		})
+		f.CanCollide = false
+		f.Transparency = 0.3
+	end
+
+	-- FarmSpawn points (10 positions, tagged)
+	local cols = { -80, -40, 0, 40, 80 }
+	local rows = { 280, 320 }
+	for _, row in ipairs(rows) do
+		for _, col in ipairs(cols) do
+			local sp = _part(root, {
+				Name      = "FarmSpawnPoint",
+				Size      = Vector3.new(4, 0.5, 4),
+				Position  = Vector3.new(col, 1.5, row),
+				Color     = Color3.fromRGB(255, 220, 60),
+				Material  = MAT.NEON,
+				CanCollide = false,
+				CastShadow = false,
+				Transparency = 0.5,
+			})
+			_tag(sp, "FarmSpawn")
+		end
+	end
+end
+
+-- ─── Race track ──────────────────────────────────────────────────────────────
+-- Straight Z axis: start Z=+600, finish Z=-600 (1200 studs total)
+-- Track width: 30 studs. Curves handled with angled sections.
+
+local function _buildTrack(root)
+	-- Main straight sections
+	local straights = {
+		-- { centerX, centerZ, length, rotation_Y_deg }
+		{ 0,    100,  200, 0  },   -- section 1: straight toward craft area
+		{ 0,   -100,  200, 0  },   -- section 2
+		{ 0,   -300,  200, 0  },   -- section 3
+		{ 0,   -500,  200, 0  },   -- section 4
+		{ 0,   -600,   60, 0  },   -- near finish
+	}
+
+	for i, s in ipairs(straights) do
+		_part(root, {
+			Name     = "TrackStraight_" .. i,
+			Size     = Vector3.new(30, 1, s[3]),
+			Position = Vector3.new(s[1], 0.5, s[2]),
+			Color    = C.TRACK,
+			Material = MAT.TRACK,
+		})
+
+		-- White edge lines
+		for _, side in ipairs({ -14, 14 }) do
+			_part(root, {
+				Name     = "TrackEdge_" .. i,
+				Size     = Vector3.new(1, 1.1, s[3]),
+				Position = Vector3.new(s[1] + side, 0.5, s[2]),
+				Color    = C.TRACK_EDGE,
+				Material = MAT.METAL,
+				CanCollide = false,
+			})
+		end
+	end
+
+	-- Connector from farm exit to track start
+	_part(root, {
+		Name     = "TrackStart",
+		Size     = Vector3.new(30, 1, 200),
+		Position = Vector3.new(0, 0.5, 200),
+		Color    = C.TRACK,
+		Material = MAT.TRACK,
+	})
+end
+
+-- ─── Mud zones (FOREST hazard) ────────────────────────────────────────────────
+
+local function _buildMudZones(root)
+	local mudZoneData = {
+		{ 0, 0.6, 20,  30, -50  },   -- zone 1: wide center strip
+		{ 8, 0.6, 14,  20, -200 },   -- zone 2: off-center
+		{ -5,0.6, 18,  25, -380 },   -- zone 3
+		{ 3, 0.6, 22,  35, -480 },   -- zone 4: before finish
+	}
+	for i, mz in ipairs(mudZoneData) do
+		local mud = _part(root, {
+			Name     = "MudZone_" .. i,
+			Size     = Vector3.new(mz[3], 0.4, mz[4]),
+			Position = Vector3.new(mz[1], mz[2], mz[5]),
+			Color    = C.MUD,
+			Material = MAT.MUD,
+		})
+		mud.CanCollide = false
+		_tag(mud, "MudZone")
+	end
+end
+
+-- ─── Drift corners ────────────────────────────────────────────────────────────
+
+local function _buildDriftCorners(root)
+	-- 4 banked turns along the track
+	local corners = {
+		{ -15, 1, -80,  40, 10, 4,  -15 },   -- x, y, z, lenZ, lenX, height, bankX
+		{  15, 1, -180, 40, 10, 4,   15 },
+		{ -15, 1, -320, 40, 10, 4,  -15 },
+		{  15, 1, -460, 40, 10, 4,   15 },
+	}
+	for i, c in ipairs(corners) do
+		local corner = _part(root, {
+			Name     = "DriftCorner_" .. i,
+			Size     = Vector3.new(c[5] + 30, c[6], c[4]),
+			Position = Vector3.new(c[1], c[2], c[3]),
+			Color    = Color3.fromRGB(70, 65, 55),
+			Material = MAT.TRACK,
+		})
+		-- Slight bank angle
+		corner.CFrame = CFrame.new(c[1], c[2], c[3]) * CFrame.Angles(0, 0, math.rad(c[7] > 0 and 8 or -8))
+		_tag(corner, "DriftCorner")
+
+		-- Warning chevron markers
+		for side = -1, 1, 2 do
+			_part(root, {
+				Name     = "Chevron_" .. i,
+				Size     = Vector3.new(1.5, 3, 0.5),
+				Position = Vector3.new(c[1] + side * 16, c[2] + 2, c[3]),
+				Color    = Color3.fromRGB(255, 140, 0),
+				Material = MAT.NEON,
+				CanCollide = false,
+			})
+		end
+	end
+end
+
+-- ─── Jump ramps ───────────────────────────────────────────────────────────────
+
+local function _buildJumpRamps(root)
+	local ramps = {
+		{ 0, 0, -130 },
+		{ 0, 0, -400 },
+	}
+	for i, r in ipairs(ramps) do
+		-- Ramp approach
+		local ramp = _wedge(root, {
+			Name     = "JumpRamp_" .. i,
+			Size     = Vector3.new(20, 5, 12),
+			Position = Vector3.new(r[1], r[2] + 2.5, r[3]),
+			Color    = C.RAMP,
+			Material = MAT.DIRT,
+		})
+		ramp.CFrame = CFrame.new(r[1], r[2] + 2.5, r[3]) * CFrame.Angles(0, math.pi, 0)
+
+		-- Landing pad
+		_part(root, {
+			Name     = "LandingPad_" .. i,
+			Size     = Vector3.new(20, 1, 20),
+			Position = Vector3.new(r[1], r[2] + 0.5, r[3] - 18),
+			Color    = C.RAMP,
+			Material = MAT.DIRT,
+		})
+
+		-- Jump zone tag
+		local jz = _part(root, {
+			Name     = "JumpZone_" .. i,
+			Size     = Vector3.new(20, 8, 12),
+			Position = Vector3.new(r[1], r[2] + 4, r[3]),
+			CanCollide = false,
+			Transparency = 1,
+		})
+		_tag(jz, "JumpZone")
+	end
+end
+
+-- ─── Boost pads ───────────────────────────────────────────────────────────────
+
+local function _buildBoostPads(root)
+	local pads = {
+		{ 0, -30  },
+		{ 0, -260 },
+		{ 0, -370 },
+		{ 0, -540 },
+	}
+	for i, pd in ipairs(pads) do
+		local pad = _part(root, {
+			Name     = "BoostPad_" .. i,
+			Size     = Vector3.new(10, 0.3, 6),
+			Position = Vector3.new(pd[1], 0.7, pd[2]),
+			Color    = C.BOOST_PAD,
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+		_tag(pad, "BoostPad")
+
+		-- Arrow indicator
+		local arrow = _wedge(root, {
+			Name     = "BoostArrow_" .. i,
+			Size     = Vector3.new(4, 0.4, 4),
+			Position = Vector3.new(pd[1], 0.9, pd[2] - 3),
+			Color    = Color3.fromRGB(255, 240, 80),
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+		arrow.CFrame = CFrame.new(pd[1], 0.9, pd[2] - 3) * CFrame.Angles(0, math.pi, 0)
+	end
+end
+
+-- ─── Obstacles ───────────────────────────────────────────────────────────────
+
+local function _buildObstacles(root)
+	local obstacles = {
+		{ 8,  2, -60  },
+		{ -8, 2, -160 },
+		{ 6,  2, -290 },
+		{ -6, 2, -430 },
+		{ 0,  2, -510 },
+	}
+	for i, ob in ipairs(obstacles) do
+		local obs = _part(root, {
+			Name     = "Obstacle_" .. i,
+			Size     = Vector3.new(5, 4, 5),
+			Position = Vector3.new(ob[1], ob[2], ob[3]),
+			Color    = C.BARRIER,
+			Material = Enum.Material.SmoothPlastic,
+		})
+		_tag(obs, "Obstacle")
+
+		-- Stripe pattern (decorative smaller parts)
+		_part(root, {
+			Name     = "ObstacleStripe_" .. i,
+			Size     = Vector3.new(5.1, 1, 5.1),
+			Position = Vector3.new(ob[1], ob[2] + 0.5, ob[3]),
+			Color    = Color3.fromRGB(240, 240, 40),
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+	end
+end
+
+-- ─── Trees ───────────────────────────────────────────────────────────────────
+
+local function _buildTrees(root)
+	local rng = Random.new(42)  -- seeded for consistency
+	local treeZones = {
+		-- { xMin, xMax, zMin, zMax, count }
+		{ -150, -25, -600, 600, 40 },   -- left side
+		{   25, 150, -600, 600, 40 },   -- right side
+		{ -100, 100, 400, 600, 15 },    -- behind farm
+	}
+
+	for _, tz in ipairs(treeZones) do
+		for _ = 1, tz[5] do
+			local tx = rng:NextNumber(tz[1], tz[2])
+			local tz2 = rng:NextNumber(tz[3], tz[4])
+			local height = rng:NextNumber(10, 22)
+			local radius = rng:NextNumber(3, 7)
+
+			-- Trunk
+			_part(root, {
+				Name     = "TreeTrunk",
+				Size     = Vector3.new(radius * 0.4, height, radius * 0.4),
+				Position = Vector3.new(tx, height / 2, tz2),
+				Color    = C.TREE_TRUNK,
+				Material = MAT.WOOD,
+				CanCollide = false,
+			})
+
+			-- Canopy (2 spherical blobs)
+			local leafColour = (rng:NextNumber() > 0.4) and C.TREE_LEAF or C.TREE_LEAF2
+			for layer = 0, 1 do
+				_part(root, {
+					Name     = "TreeLeaves",
+					Size     = Vector3.new(radius * 2, radius * 1.5, radius * 2),
+					Position = Vector3.new(tx, height + radius * 0.8 * layer, tz2),
+					Color    = leafColour,
+					Material = MAT.LEAVES,
+					CanCollide = false,
+					CastShadow = false,
+				})
+			end
+		end
+	end
+end
+
+-- ─── Finish line ─────────────────────────────────────────────────────────────
+
+local function _buildFinishLine(root)
+	-- Checkered finish strip
+	for col = -14, 14, 4 do
+		for row = 0, 1 do
+			_part(root, {
+				Name     = "FinishTile",
+				Size     = Vector3.new(4, 0.3, 4),
+				Position = Vector3.new(col, 0.8, -598 + row * 4),
+				Color    = (math.floor(col / 4) + row) % 2 == 0
+					and Color3.new(1, 1, 1) or Color3.new(0, 0, 0),
+				Material = MAT.METAL,
+				CanCollide = false,
+			})
+		end
+	end
+
+	-- Finish line trigger (invisible sensor)
+	local finish = _part(root, {
+		Name       = "FinishLine",
+		Size       = Vector3.new(30, 8, 2),
+		Position   = Vector3.new(0, 4, -599),
+		CanCollide = false,
+		Transparency = 1,
+	})
+	_tag(finish, "FinishLine")
+
+	-- Arch poles
+	for side = -1, 1, 2 do
+		_part(root, {
+			Name     = "FinishPole",
+			Size     = Vector3.new(1.5, 14, 1.5),
+			Position = Vector3.new(side * 16, 7, -599),
+			Color    = C.FINISH_LINE,
+			Material = MAT.METAL,
+		})
+	end
+	-- Arch bar
+	_part(root, {
+		Name     = "FinishArch",
+		Size     = Vector3.new(34, 2, 1.5),
+		Position = Vector3.new(0, 14, -599),
+		Color    = Color3.fromRGB(240, 60, 60),
+		Material = MAT.NEON,
+		CanCollide = false,
+	})
+end
+
+-- ─── Start grid ──────────────────────────────────────────────────────────────
+
+local function _buildStartGrid(root)
+	-- Grid markers: 2 rows × 5 columns
+	local cols = { -16, -8, 0, 8, 16 }
+	local rows = { 165, 180 }
+	for row, z in ipairs(rows) do
+		for col, x in ipairs(cols) do
+			local idx = (row - 1) * 5 + col
+			-- Coloured grid square
+			_part(root, {
+				Name     = "StartBox_" .. idx,
+				Size     = Vector3.new(7, 0.2, 7),
+				Position = Vector3.new(x, 0.6, z),
+				Color    = Color3.fromRGB(60, 120, 255),
+				Material = MAT.NEON,
+				CanCollide = false,
+			})
+			-- Number marker
+			local numPart = _part(root, {
+				Name     = "StartNum_" .. idx,
+				Size     = Vector3.new(2, 2, 0.3),
+				Position = Vector3.new(x, 1.5, z + 3),
+				Color    = Color3.new(1, 1, 1),
+				Material = MAT.NEON,
+				CanCollide = false,
+			})
+		end
+	end
+end
+
+-- ─── Main build function ─────────────────────────────────────────────────────
+
+function MapBuilders.buildForest()
+	local root = _getOrCreateMap()
+
+	_buildGround(root)
+	_buildFarmArea(root)
+	_buildTrack(root)
+	_buildMudZones(root)
+	_buildDriftCorners(root)
+	_buildJumpRamps(root)
+	_buildBoostPads(root)
+	_buildObstacles(root)
+	_buildTrees(root)
+	_buildFinishLine(root)
+	_buildStartGrid(root)
+
+	-- Tag the whole model
+	CollectionService:AddTag(root, "BiomeMap")
+	root:SetAttribute("Biome", "FOREST")
+
+	print("[ForestMapBuilder] Built FOREST map (" .. #root:GetChildren() .. " objects)")
+	return root
+end
+
+-- ─── Auto-build when this script runs (called by MapManager) ─────────────────
+-- Wrapped in pcall so errors don't crash the server
+local ok, err = pcall(MapBuilders.buildForest)
+if not ok then
+	warn("[ForestMapBuilder] Build failed: " .. tostring(err))
+end
+
+return MapBuilders

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -1,0 +1,335 @@
+-- OceanMapBuilder.server.lua
+-- Procedurally builds the OCEAN biome map:
+--   - Open water plane with islands
+--   - Race track as floating docks / bridges
+--   - Buoyancy zones, boost pads, obstacles, finish line
+-- Resolves: Issue #9
+
+local CollectionService = game:GetService("CollectionService")
+
+local C = {
+	WATER      = Color3.fromRGB(30,  90,  180),
+	DOCK       = Color3.fromRGB(140, 100, 60),
+	SAND       = Color3.fromRGB(220, 190, 120),
+	FOAM       = Color3.fromRGB(200, 225, 255),
+	BARRIER    = Color3.fromRGB(255, 80,  40),
+	BOOST      = Color3.fromRGB(60,  200, 255),
+	ISLAND     = Color3.fromRGB(80,  140, 60),
+	PALM_TRUNK = Color3.fromRGB(120, 85,  40),
+	PALM_LEAF  = Color3.fromRGB(60,  160, 50),
+	BUOY_RED   = Color3.fromRGB(220, 50,  50),
+	BUOY_WHITE = Color3.fromRGB(240, 240, 240),
+}
+
+local MAT = {
+	WATER  = Enum.Material.SmoothPlastic,
+	WOOD   = Enum.Material.Wood,
+	SAND   = Enum.Material.Sand,
+	METAL  = Enum.Material.Metal,
+	NEON   = Enum.Material.Neon,
+	LEAVES = Enum.Material.LeafyGrass,
+	ROCK   = Enum.Material.Rock,
+}
+
+local WATER_Y = 0  -- matches BiomeConfig waterPlaneY
+
+local function _part(parent, props)
+	local p = Instance.new("Part")
+	p.Anchored   = true
+	p.CanCollide = true
+	for k, v in pairs(props) do pcall(function() p[k] = v end) end
+	p.Parent = parent
+	return p
+end
+
+local function _wedge(parent, props)
+	local p = Instance.new("WedgePart")
+	p.Anchored   = true
+	p.CanCollide = true
+	for k, v in pairs(props) do pcall(function() p[k] = v end) end
+	p.Parent = parent
+	return p
+end
+
+local function _tag(part, tagName)
+	CollectionService:AddTag(part, tagName)
+end
+
+local function _getOrCreateMap()
+	local maps = workspace:FindFirstChild("Maps") or (function()
+		local f = Instance.new("Folder"); f.Name = "Maps"; f.Parent = workspace; return f
+	end)()
+	local existing = maps:FindFirstChild("OceanMap")
+	if existing then existing:Destroy() end
+	local model = Instance.new("Model")
+	model.Name   = "OceanMap"
+	model.Parent = maps
+	return model
+end
+
+-- ─── Water plane ────────────────────────────────────────────────────────────
+
+local function _buildWater(root)
+	local water = _part(root, {
+		Name         = "WaterPlane",
+		Size         = Vector3.new(600, 4, 1600),
+		Position     = Vector3.new(0, WATER_Y - 2, 0),
+		Color        = C.WATER,
+		Material     = MAT.WATER,
+		Transparency = 0.35,
+		CanCollide   = false,
+	})
+	-- Deep zone (darker)
+	_part(root, {
+		Name         = "DeepWater",
+		Size         = Vector3.new(600, 1, 1600),
+		Position     = Vector3.new(0, WATER_Y - 6, 0),
+		Color        = Color3.fromRGB(15, 50, 120),
+		Material     = MAT.WATER,
+		CanCollide   = false,
+	})
+end
+
+-- ─── Farm island (Z = 250 to 500) ────────────────────────────────────────────
+
+local function _buildFarmIsland(root)
+	-- Main island body
+	_part(root, {
+		Name     = "FarmIsland",
+		Size     = Vector3.new(160, 6, 260),
+		Position = Vector3.new(0, WATER_Y - 1, 375),
+		Color    = C.SAND,
+		Material = MAT.SAND,
+	})
+	-- Grass top
+	_part(root, {
+		Name     = "FarmGrass",
+		Size     = Vector3.new(140, 1, 230),
+		Position = Vector3.new(0, WATER_Y + 2.5, 375),
+		Color    = Color3.fromRGB(80, 160, 70),
+		Material = Enum.Material.Grass,
+	})
+
+	-- Spawn points
+	local cols = { -50, -25, 0, 25, 50 }
+	local rows = { 290, 330 }
+	for _, row in ipairs(rows) do
+		for _, col in ipairs(cols) do
+			local sp = _part(root, {
+				Name      = "FarmSpawnPoint",
+				Size      = Vector3.new(4, 0.5, 4),
+				Position  = Vector3.new(col, WATER_Y + 3.5, row),
+				Color     = Color3.fromRGB(255, 220, 60),
+				Material  = MAT.NEON,
+				CanCollide = false,
+				Transparency = 0.5,
+			})
+			_tag(sp, "FarmSpawn")
+		end
+	end
+
+	-- Palm trees on island
+	local rng = Random.new(99)
+	for _ = 1, 8 do
+		local tx = rng:NextNumber(-60, 60)
+		local tz = rng:NextNumber(260, 490)
+		local h  = rng:NextNumber(8, 14)
+		_part(root, {
+			Name     = "PalmTrunk",
+			Size     = Vector3.new(1.2, h, 1.2),
+			Position = Vector3.new(tx, WATER_Y + 2.5 + h / 2, tz),
+			Color    = C.PALM_TRUNK,
+			Material = MAT.WOOD,
+			CanCollide = false,
+		})
+		for i = 0, 4 do
+			local angle = (i / 5) * math.pi * 2
+			local leafX = math.cos(angle) * 4
+			local leafZ = math.sin(angle) * 4
+			_part(root, {
+				Name     = "PalmLeaf",
+				Size     = Vector3.new(0.6, 0.3, 8),
+				Position = Vector3.new(tx + leafX / 2, WATER_Y + 2.5 + h + 0.5, tz + leafZ / 2),
+				Color    = C.PALM_LEAF,
+				Material = MAT.LEAVES,
+				CFrame   = CFrame.new(tx + leafX / 2, WATER_Y + 2.5 + h + 0.5, tz + leafZ / 2)
+					* CFrame.Angles(0, angle, math.rad(-20)),
+				CanCollide = false,
+			})
+		end
+	end
+end
+
+-- ─── Floating dock track ─────────────────────────────────────────────────────
+
+local DOCK_Y = WATER_Y + 1.5
+
+local function _buildDocks(root)
+	-- Main dock sections along Z axis
+	local sections = {
+		{ 0,   DOCK_Y, 150,  60, 220 },   -- x, y, z, width, length
+		{ 0,   DOCK_Y, 0,    50, 200 },
+		{ 0,   DOCK_Y, -150, 50, 200 },
+		{ 0,   DOCK_Y, -340, 50, 200 },
+		{ 0,   DOCK_Y, -530, 50, 140 },
+	}
+
+	for i, s in ipairs(sections) do
+		_part(root, {
+			Name     = "Dock_" .. i,
+			Size     = Vector3.new(s[4], 1.5, s[5]),
+			Position = Vector3.new(s[1], s[2], s[3]),
+			Color    = C.DOCK,
+			Material = MAT.WOOD,
+		})
+
+		-- Wood plank texture strips
+		for plank = -math.floor(s[5] / 2), math.floor(s[5] / 2), 4 do
+			_part(root, {
+				Name     = "Plank",
+				Size     = Vector3.new(s[4], 0.2, 2),
+				Position = Vector3.new(s[1], s[2] + 0.85, s[3] + plank),
+				Color    = Color3.fromRGB(160, 115, 70),
+				Material = MAT.WOOD,
+				CanCollide = false,
+			})
+		end
+
+		-- Rope railings
+		for side = -1, 1, 2 do
+			_part(root, {
+				Name     = "Railing_" .. i,
+				Size     = Vector3.new(0.4, 2, s[5]),
+				Position = Vector3.new(s[1] + side * (s[4] / 2 - 0.5), s[2] + 1.5, s[3]),
+				Color    = C.DOCK,
+				Material = MAT.WOOD,
+				CanCollide = false,
+			})
+		end
+	end
+end
+
+-- ─── Buoyancy zones ──────────────────────────────────────────────────────────
+
+local function _buildBuoyancyZones(root)
+	-- Large underwater trigger zones where buoyancy kicks in
+	local zones = {
+		{ 0, -2, 100,  80, 200 },
+		{ 0, -2, -80,  80, 200 },
+		{ 0, -2, -280, 80, 200 },
+	}
+	for i, bz in ipairs(zones) do
+		local zone = _part(root, {
+			Name         = "BuoyancyZone_" .. i,
+			Size         = Vector3.new(bz[4], 8, bz[5]),
+			Position     = Vector3.new(bz[1], bz[2], bz[3]),
+			CanCollide   = false,
+			Transparency = 1,
+		})
+		_tag(zone, "BuoyancyZone")
+	end
+end
+
+-- ─── Buoys (navigation markers + obstacles) ───────────────────────────────────
+
+local function _buildBuoys(root)
+	local buoys = {
+		{ -20, 0,  -50 }, { 20, 0, -50 },
+		{ -20, 0, -200 }, { 20, 0, -200 },
+		{ -20, 0, -380 }, { 20, 0, -380 },
+	}
+	for i, b in ipairs(buoys) do
+		local buoy = _part(root, {
+			Name     = "Buoy_" .. i,
+			Size     = Vector3.new(3, 5, 3),
+			Position = Vector3.new(b[1], WATER_Y + 2, b[3]),
+			Color    = i % 2 == 0 and C.BUOY_RED or C.BUOY_WHITE,
+			Material = MAT.NEON,
+		})
+		_tag(buoy, "Obstacle")
+	end
+end
+
+-- ─── Boost pads ──────────────────────────────────────────────────────────────
+
+local function _buildBoostPads(root)
+	local pads = { -20, -140, -310, -490 }
+	for i, z in ipairs(pads) do
+		local pad = _part(root, {
+			Name     = "BoostPad_" .. i,
+			Size     = Vector3.new(10, 0.3, 6),
+			Position = Vector3.new(0, DOCK_Y + 0.9, z),
+			Color    = C.BOOST,
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+		_tag(pad, "BoostPad")
+	end
+end
+
+-- ─── Finish line ─────────────────────────────────────────────────────────────
+
+local function _buildFinishLine(root)
+	for col = -12, 12, 4 do
+		for row = 0, 1 do
+			_part(root, {
+				Name     = "FinishTile",
+				Size     = Vector3.new(4, 0.3, 4),
+				Position = Vector3.new(col, DOCK_Y + 0.9, -598 + row * 4),
+				Color    = (math.floor(col / 4) + row) % 2 == 0
+					and Color3.new(1, 1, 1) or Color3.new(0, 0, 0),
+				Material = MAT.METAL,
+				CanCollide = false,
+			})
+		end
+	end
+
+	local finish = _part(root, {
+		Name       = "FinishLine",
+		Size       = Vector3.new(30, 8, 2),
+		Position   = Vector3.new(0, DOCK_Y + 4, -599),
+		CanCollide = false,
+		Transparency = 1,
+	})
+	_tag(finish, "FinishLine")
+
+	for side = -1, 1, 2 do
+		_part(root, {
+			Name     = "FinishPole",
+			Size     = Vector3.new(1.5, 14, 1.5),
+			Position = Vector3.new(side * 16, DOCK_Y + 7, -599),
+			Color    = C.BUOY_WHITE,
+			Material = MAT.METAL,
+		})
+	end
+	_part(root, {
+		Name     = "FinishArch",
+		Size     = Vector3.new(34, 2, 1.5),
+		Position = Vector3.new(0, DOCK_Y + 14, -599),
+		Color    = Color3.fromRGB(40, 160, 255),
+		Material = MAT.NEON,
+		CanCollide = false,
+	})
+end
+
+-- ─── Main build ──────────────────────────────────────────────────────────────
+
+local function buildOcean()
+	local root = _getOrCreateMap()
+	_buildWater(root)
+	_buildFarmIsland(root)
+	_buildDocks(root)
+	_buildBuoyancyZones(root)
+	_buildBuoys(root)
+	_buildBoostPads(root)
+	_buildFinishLine(root)
+
+	CollectionService:AddTag(root, "BiomeMap")
+	root:SetAttribute("Biome", "OCEAN")
+
+	print("[OceanMapBuilder] Built OCEAN map (" .. #root:GetChildren() .. " objects)")
+	return root
+end
+
+local ok, err = pcall(buildOcean)
+if not ok then warn("[OceanMapBuilder] Build failed: " .. tostring(err)) end

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -1,0 +1,343 @@
+-- SkyMapBuilder.server.lua
+-- Procedurally builds the SKY biome map:
+--   - Floating platform farm area
+--   - Sky race track with platforms and gaps
+--   - Updraft zones, kill plane, boost pads, obstacles
+-- Resolves: Issue #10
+
+local CollectionService = game:GetService("CollectionService")
+
+local C = {
+	CLOUD      = Color3.fromRGB(235, 240, 255),
+	PLATFORM   = Color3.fromRGB(180, 160, 220),
+	PLATFORM2  = Color3.fromRGB(140, 120, 190),
+	CRYSTAL    = Color3.fromRGB(160, 120, 255),
+	BOOST      = Color3.fromRGB(200, 160, 255),
+	BARRIER    = Color3.fromRGB(255, 100, 80),
+	UPDRAFT    = Color3.fromRGB(120, 200, 255),
+	STAR       = Color3.fromRGB(255, 240, 100),
+	ARCH       = Color3.fromRGB(180, 100, 255),
+}
+
+local MAT = {
+	CLOUD   = Enum.Material.SmoothPlastic,
+	ROCK    = Enum.Material.Rock,
+	CRYSTAL = Enum.Material.Neon,
+	NEON    = Enum.Material.Neon,
+	METAL   = Enum.Material.Metal,
+	ICE     = Enum.Material.Ice,
+}
+
+local SKY_BASE_Y = 80   -- everything lives up here
+
+local function _part(parent, props)
+	local p = Instance.new("Part")
+	p.Anchored   = true
+	p.CanCollide = true
+	for k, v in pairs(props) do pcall(function() p[k] = v end) end
+	p.Parent = parent
+	return p
+end
+
+local function _tag(part, tagName)
+	CollectionService:AddTag(part, tagName)
+end
+
+local function _getOrCreateMap()
+	local maps = workspace:FindFirstChild("Maps") or (function()
+		local f = Instance.new("Folder"); f.Name = "Maps"; f.Parent = workspace; return f
+	end)()
+	local existing = maps:FindFirstChild("SkyMap")
+	if existing then existing:Destroy() end
+	local model = Instance.new("Model")
+	model.Name   = "SkyMap"
+	model.Parent = maps
+	return model
+end
+
+-- ─── Cloud decoration layer ──────────────────────────────────────────────────
+
+local function _buildClouds(root)
+	local rng = Random.new(77)
+	for _ = 1, 30 do
+		local cx = rng:NextNumber(-200, 200)
+		local cy = SKY_BASE_Y + rng:NextNumber(-20, 30)
+		local cz = rng:NextNumber(-650, 650)
+		local cw = rng:NextNumber(30, 80)
+		local cd = rng:NextNumber(15, 40)
+
+		_part(root, {
+			Name         = "Cloud",
+			Size         = Vector3.new(cw, 8, cd),
+			Position     = Vector3.new(cx, cy, cz),
+			Color        = C.CLOUD,
+			Material     = MAT.CLOUD,
+			CanCollide   = false,
+			CastShadow   = false,
+			Transparency = 0.5,
+		})
+		-- second blob
+		_part(root, {
+			Name         = "CloudBlob",
+			Size         = Vector3.new(cw * 0.7, 10, cd * 0.7),
+			Position     = Vector3.new(cx + rng:NextNumber(-10, 10), cy + 5, cz + rng:NextNumber(-8, 8)),
+			Color        = C.CLOUD,
+			Material     = MAT.CLOUD,
+			CanCollide   = false,
+			CastShadow   = false,
+			Transparency = 0.45,
+		})
+	end
+end
+
+-- ─── Farm platform (Z = 300 to 500) ─────────────────────────────────────────
+
+local function _buildFarmPlatform(root)
+	-- Large floating platform for farming
+	_part(root, {
+		Name     = "FarmPlatform",
+		Size     = Vector3.new(180, 8, 220),
+		Position = Vector3.new(0, SKY_BASE_Y - 4, 390),
+		Color    = C.PLATFORM,
+		Material = MAT.ROCK,
+	})
+	-- Crystal pillars underneath for visual
+	for _, pos in ipairs({ {-70, 390}, {70, 390}, {0, 310}, {0, 470} }) do
+		_part(root, {
+			Name         = "CrystalPillar",
+			Size         = Vector3.new(5, 40, 5),
+			Position     = Vector3.new(pos[1], SKY_BASE_Y - 28, pos[2]),
+			Color        = C.CRYSTAL,
+			Material     = MAT.CRYSTAL,
+			CanCollide   = false,
+			CastShadow   = false,
+		})
+	end
+
+	-- Spawn points on platform
+	local cols = { -60, -30, 0, 30, 60 }
+	local rows = { 340, 380 }
+	for _, row in ipairs(rows) do
+		for _, col in ipairs(cols) do
+			local sp = _part(root, {
+				Name      = "FarmSpawnPoint",
+				Size      = Vector3.new(4, 0.5, 4),
+				Position  = Vector3.new(col, SKY_BASE_Y + 4.5, row),
+				Color     = Color3.fromRGB(255, 220, 60),
+				Material  = MAT.NEON,
+				CanCollide = false,
+				Transparency = 0.5,
+			})
+			_tag(sp, "FarmSpawn")
+		end
+	end
+end
+
+-- ─── Sky race track (stepping stone platforms) ───────────────────────────────
+
+local PLATFORM_DATA = {
+	-- { centerX, centerY_offset, centerZ, width, length }
+	{ 0,    0,    200,  40, 80  },   -- transition from farm
+	{ 0,    0,    110,  35, 60  },
+	{ -15, -5,   30,   35, 60  },   -- slight drop + offset
+	{ 10,   3,  -60,   35, 60  },   -- rise
+	{ 0,   -8,  -160,  40, 80  },   -- wide section
+	{ 15,   0,  -270,  30, 60  },
+	{ -10, -5,  -370,  30, 60  },
+	{ 0,    5,  -460,  35, 80  },
+	{ 0,    0,  -560,  40, 80  },   -- near finish
+}
+
+local function _buildTrackPlatforms(root)
+	for i, pd in ipairs(PLATFORM_DATA) do
+		local y = SKY_BASE_Y + pd[2]
+		_part(root, {
+			Name     = "TrackPlatform_" .. i,
+			Size     = Vector3.new(pd[4], 5, pd[5]),
+			Position = Vector3.new(pd[1], y - 2.5, pd[3]),
+			Color    = i % 2 == 0 and C.PLATFORM or C.PLATFORM2,
+			Material = MAT.ROCK,
+		})
+
+		-- Edge glow strips
+		for side = -1, 1, 2 do
+			_part(root, {
+				Name     = "TrackGlow_" .. i,
+				Size     = Vector3.new(1, 0.5, pd[5]),
+				Position = Vector3.new(pd[1] + side * (pd[4] / 2 - 0.5), y + 0.3, pd[3]),
+				Color    = C.CRYSTAL,
+				Material = MAT.NEON,
+				CanCollide = false,
+				CastShadow = false,
+			})
+		end
+	end
+end
+
+-- ─── Updraft zones ───────────────────────────────────────────────────────────
+
+local function _buildUpdraftZones(root)
+	local zones = {
+		{ 0,  SKY_BASE_Y - 10, 80   },
+		{ 0,  SKY_BASE_Y - 10, -110 },
+		{ 0,  SKY_BASE_Y - 10, -320 },
+	}
+	for i, uz in ipairs(zones) do
+		-- Visual column (neon blue cylinder approximation using part)
+		local visual = _part(root, {
+			Name         = "UpdraftVisual_" .. i,
+			Size         = Vector3.new(12, 40, 12),
+			Position     = Vector3.new(uz[1], uz[2], uz[3]),
+			Color        = C.UPDRAFT,
+			Material     = MAT.NEON,
+			CanCollide   = false,
+			Transparency = 0.75,
+		})
+
+		-- Trigger zone (invisible, larger)
+		local trigger = _part(root, {
+			Name         = "UpdraftZone_" .. i,
+			Size         = Vector3.new(16, 60, 16),
+			Position     = Vector3.new(uz[1], uz[2], uz[3]),
+			CanCollide   = false,
+			Transparency = 1,
+		})
+		_tag(trigger, "UpdraftZone")
+	end
+end
+
+-- ─── Obstacles (floating crystals / rocks) ───────────────────────────────────
+
+local function _buildObstacles(root)
+	local obs = {
+		{ 8,   SKY_BASE_Y + 2, -30  },
+		{ -8,  SKY_BASE_Y + 2, -200 },
+		{ 10,  SKY_BASE_Y + 2, -310 },
+		{ -10, SKY_BASE_Y + 2, -400 },
+		{ 0,   SKY_BASE_Y + 3, -510 },
+	}
+	for i, ob in ipairs(obs) do
+		local obstacle = _part(root, {
+			Name     = "Obstacle_" .. i,
+			Size     = Vector3.new(5, 6, 5),
+			Position = Vector3.new(ob[1], ob[2], ob[3]),
+			Color    = C.CRYSTAL,
+			Material = MAT.CRYSTAL,
+		})
+		_tag(obstacle, "Obstacle")
+
+		-- Rotating glow ring (static decoration)
+		_part(root, {
+			Name     = "ObstacleRing_" .. i,
+			Size     = Vector3.new(8, 0.5, 8),
+			Position = Vector3.new(ob[1], ob[2] - 1, ob[3]),
+			Color    = C.STAR,
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+	end
+end
+
+-- ─── Boost pads ──────────────────────────────────────────────────────────────
+
+local function _buildBoostPads(root)
+	local pads = {
+		{ 0, SKY_BASE_Y + 0.8, -20  },
+		{ 0, SKY_BASE_Y - 4.7, -150 },  -- slightly lower platform
+		{ 0, SKY_BASE_Y + 2.8, -360 },
+		{ 0, SKY_BASE_Y + 0.8, -480 },
+		{ 0, SKY_BASE_Y + 0.8, -545 },
+	}
+	for i, pd in ipairs(pads) do
+		local pad = _part(root, {
+			Name     = "BoostPad_" .. i,
+			Size     = Vector3.new(10, 0.3, 6),
+			Position = Vector3.new(pd[1], pd[2], pd[3]),
+			Color    = C.BOOST,
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+		_tag(pad, "BoostPad")
+	end
+end
+
+-- ─── Finish line ─────────────────────────────────────────────────────────────
+
+local function _buildFinishLine(root)
+	local finY = SKY_BASE_Y
+
+	for col = -12, 12, 4 do
+		for row = 0, 1 do
+			_part(root, {
+				Name     = "FinishTile",
+				Size     = Vector3.new(4, 0.3, 4),
+				Position = Vector3.new(col, finY + 0.9, -598 + row * 4),
+				Color    = (math.floor(col / 4) + row) % 2 == 0
+					and Color3.new(1, 1, 1) or Color3.new(0, 0, 0),
+				Material = MAT.METAL,
+				CanCollide = false,
+			})
+		end
+	end
+
+	local finish = _part(root, {
+		Name       = "FinishLine",
+		Size       = Vector3.new(40, 10, 2),
+		Position   = Vector3.new(0, finY + 5, -599),
+		CanCollide = false,
+		Transparency = 1,
+	})
+	_tag(finish, "FinishLine")
+
+	for side = -1, 1, 2 do
+		_part(root, {
+			Name     = "FinishPole",
+			Size     = Vector3.new(1.5, 16, 1.5),
+			Position = Vector3.new(side * 20, finY + 8, -599),
+			Color    = C.ARCH,
+			Material = MAT.CRYSTAL,
+		})
+	end
+	_part(root, {
+		Name     = "FinishArch",
+		Size     = Vector3.new(42, 2.5, 1.5),
+		Position = Vector3.new(0, finY + 16, -599),
+		Color    = C.ARCH,
+		Material = MAT.NEON,
+		CanCollide = false,
+	})
+
+	-- Star decorations on arch
+	for i = -16, 16, 8 do
+		_part(root, {
+			Name     = "ArchStar",
+			Size     = Vector3.new(2, 2, 0.5),
+			Position = Vector3.new(i, finY + 16, -598),
+			Color    = C.STAR,
+			Material = MAT.NEON,
+			CanCollide = false,
+		})
+	end
+end
+
+-- ─── Main build ──────────────────────────────────────────────────────────────
+
+local function buildSky()
+	local root = _getOrCreateMap()
+	_buildClouds(root)
+	_buildFarmPlatform(root)
+	_buildTrackPlatforms(root)
+	_buildUpdraftZones(root)
+	_buildObstacles(root)
+	_buildBoostPads(root)
+	_buildFinishLine(root)
+
+	CollectionService:AddTag(root, "BiomeMap")
+	root:SetAttribute("Biome", "SKY")
+
+	print("[SkyMapBuilder] Built SKY map (" .. #root:GetChildren() .. " objects)")
+	return root
+end
+
+local ok, err = pcall(buildSky)
+if not ok then warn("[SkyMapBuilder] Build failed: " .. tostring(err)) end

--- a/roblox/ServerScriptService/MapBuilders/TerrainPainter.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/TerrainPainter.server.lua
@@ -1,0 +1,179 @@
+-- TerrainPainter.server.lua
+-- Uses workspace.Terrain API to paint biome-specific terrain
+-- underneath the procedural map parts.
+-- Runs once at server start, before MapBuilders execute.
+-- Resolves: Issue #8 #9 #10 (terrain layer)
+
+local Terrain = workspace.Terrain
+
+-- ─── Terrain material enums ───────────────────────────────────────────────────
+
+local TM = Enum.Material
+
+-- ─── Helper: fill a box region with terrain material ─────────────────────────
+
+local function _fillBox(x, y, z, sizeX, sizeY, sizeZ, material)
+	local region = Region3.new(
+		Vector3.new(x - sizeX / 2, y - sizeY / 2, z - sizeZ / 2),
+		Vector3.new(x + sizeX / 2, y + sizeY / 2, z + sizeZ / 2)
+	)
+	Terrain:FillBlock(region.CFrame, region.Size, material)
+end
+
+-- ─── Helper: fill a cylinder ──────────────────────────────────────────────────
+
+local function _fillCylinder(x, y, z, height, radius, material)
+	local cf     = CFrame.new(x, y, z)
+	Terrain:FillCylinder(cf, height, radius, material)
+end
+
+-- ─── Helper: fill a sphere ────────────────────────────────────────────────────
+
+local function _fillSphere(x, y, z, radius, material)
+	Terrain:FillBall(Vector3.new(x, y, z), radius, material)
+end
+
+-- ─── Clear all terrain first ─────────────────────────────────────────────────
+
+local function _clearTerrain()
+	Terrain:Clear()
+end
+
+-- ─── FOREST terrain ──────────────────────────────────────────────────────────
+
+local function _paintForest()
+	-- Ground layer (grass over dirt)
+	_fillBox(0, -6, 0, 400, 8, 1400, TM.Grass)
+	_fillBox(0, -14, 0, 400, 8, 1400, TM.Ground)
+	_fillBox(0, -22, 0, 400, 8, 1400, TM.Rock)
+
+	-- Farm area: dirt patch
+	_fillBox(0, -2, 350, 220, 3, 310, TM.Ground)
+	_fillBox(0, -0.5, 350, 200, 1, 290, TM.Mud)
+
+	-- Mud zones (slightly depressed)
+	local mudAreas = {
+		{ 0, -1, -50,  35, 1.5, 35 },
+		{ 8, -1, -200, 25, 1.5, 25 },
+		{ -5,-1, -380, 30, 1.5, 30 },
+		{ 3, -1, -480, 40, 1.5, 40 },
+	}
+	for _, m in ipairs(mudAreas) do
+		_fillBox(m[1], m[2], m[3], m[4], m[5], m[6], TM.Mud)
+	end
+
+	-- Hills on sides (decorative)
+	local rng = Random.new(12)
+	for _ = 1, 20 do
+		local hx = rng:NextNumber(-150, -40) * (rng:NextNumber() > 0.5 and 1 or -1)
+		local hz = rng:NextNumber(-580, 580)
+		local hr = rng:NextNumber(10, 25)
+		_fillSphere(hx, -hr * 0.5, hz, hr, TM.Grass)
+	end
+
+	-- River / stream crossing track at Z=-120 (water hazard visual)
+	_fillBox(0, -2, -120, 30, 2, 20, TM.Water)
+
+	print("[TerrainPainter] FOREST terrain painted")
+end
+
+-- ─── OCEAN terrain ───────────────────────────────────────────────────────────
+
+local function _paintOcean()
+	-- Seabed
+	_fillBox(0, -30, 0, 600, 20, 1600, TM.Sand)
+	_fillBox(0, -50, 0, 600, 20, 1600, TM.Rock)
+
+	-- Water volume
+	_fillBox(0, -8, 0, 600, 16, 1600, TM.Water)
+
+	-- Farm island sand base
+	_fillBox(0, -4, 375, 170, 8, 270, TM.Sand)
+	_fillBox(0, 2, 375, 140, 2, 230, TM.Grass)
+
+	-- Coral reef decorations (shallow rocks near track)
+	local rng = Random.new(55)
+	for _ = 1, 30 do
+		local rx = rng:NextNumber(-100, 100)
+		local rz = rng:NextNumber(-580, 180)
+		local rr = rng:NextNumber(2, 8)
+		_fillSphere(rx, -12, rz, rr, TM.Rock)
+	end
+
+	-- Sandy shallows near island
+	for _ = 1, 15 do
+		local sx = rng:NextNumber(-120, 120)
+		local sz = rng:NextNumber(200, 550)
+		_fillSphere(sx, -5, sz, rng:NextNumber(5, 12), TM.Sand)
+	end
+
+	print("[TerrainPainter] OCEAN terrain painted")
+end
+
+-- ─── SKY terrain ─────────────────────────────────────────────────────────────
+
+local function _paintSky()
+	-- Small floating rock islands beneath platforms for visual depth
+	local rng = Random.new(33)
+
+	for _ = 1, 12 do
+		local rx = rng:NextNumber(-100, 100)
+		local ry = rng:NextNumber(20, 60)
+		local rz = rng:NextNumber(-580, 580)
+		local rr = rng:NextNumber(8, 20)
+		_fillSphere(rx, ry, rz, rr, TM.Rock)
+		-- Grass cap
+		_fillSphere(rx, ry + rr * 0.6, rz, rr * 0.5, TM.Grass)
+	end
+
+	-- Main farm platform base (rocky underside)
+	_fillBox(0, 65, 390, 180, 20, 220, TM.Rock)
+	_fillBox(0, 79, 390, 175, 3, 215, TM.Grass)
+
+	-- Track platform bases
+	local platZ = { 200, 110, 30, -60, -160, -270, -370, -460, -560 }
+	for _, z in ipairs(platZ) do
+		_fillBox(0, 72, z, 40, 10, 70, TM.Rock)
+	end
+
+	print("[TerrainPainter] SKY terrain painted")
+end
+
+-- ─── Dispatch ────────────────────────────────────────────────────────────────
+-- Wait for MapManager / BiomeSelected to know which biome to paint.
+-- Listen to the map model attribute set by MapBuilders.
+
+local function _detectAndPaint()
+	-- Watch for map models being created
+	workspace:DescendantAdded:Connect(function(desc)
+		if desc:IsA("Model") and desc:GetAttribute("Biome") then
+			local biome = desc:GetAttribute("Biome")
+			_clearTerrain()
+			if biome == "FOREST" then
+				_paintForest()
+			elseif biome == "OCEAN" then
+				_paintOcean()
+			elseif biome == "SKY" then
+				_paintSky()
+			end
+		end
+	end)
+
+	-- Also check existing maps (in case MapBuilders ran first)
+	local maps = workspace:FindFirstChild("Maps")
+	if maps then
+		for _, model in ipairs(maps:GetChildren()) do
+			local biome = model:GetAttribute("Biome")
+			if biome then
+				_clearTerrain()
+				if biome == "FOREST" then _paintForest()
+				elseif biome == "OCEAN" then _paintOcean()
+				elseif biome == "SKY" then _paintSky()
+				end
+				break
+			end
+		end
+	end
+end
+
+task.defer(_detectAndPaint)


### PR DESCRIPTION
## Summary
3개 바이옴 맵을 Lua 코드로 절차적 생성. Rojo 통해 Studio 자동 반영, Play 버튼 누르면 맵이 런타임에 빌드됨.

## 맵별 주요 요소

### FOREST (#8)
- 잔디 지면 + 흙 파밍 구역 + 10개 스폰 포인트
- 레이스 트랙: 4개 머드존, 4개 드리프트 코너, 2개 점프 램프
- 4개 부스트 패드, 5개 장애물, 80그루 나무 (Seeded random)

### OCEAN (#9)
- 수면 + 해저, 농장 섬 (모래+잔디+야자수 8그루)
- 떠있는 목재 도크 트랙, 나무판자 + 로프 난간
- 3개 부력 존, 6개 부표 장애물

### SKY (#10)
- 구름 30개, 큰 플랫폼 농장 (수정 기둥 장식)
- 9개 스텝 플랫폼 트랙 (네온 엣지 글로우)
- 3개 업드래프트 존 (시각 + 트리거)

### TerrainPainter
- `Terrain:FillBlock/FillBall`로 바이옴별 지형 페인팅
- FOREST: 잔디/흙/머드/물 레이어, 언덕
- OCEAN: 모래 해저, 수량, 산호초
- SKY: 떠있는 바위섬, 잔디 캡

## Test plan
- [ ] Play 버튼 누른 후 Explorer에서 Maps/ForestMap 생성 확인
- [ ] Terrain 페인팅 적용 확인 (뷰포트에서 지형 표시)
- [ ] MudZone, BoostPad, Obstacle 태그 확인 (CollectionService)
- [ ] FarmSpawn 태그 10개 존재 확인

Closes #8, #9, #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)