### PR TITLE
Solo/small-group test mode: start with 1 player, no lobby wait

### DIFF
--- a/roblox/ReplicatedStorage/Shared/Constants.lua
+++ b/roblox/ReplicatedStorage/Shared/Constants.lua
@@ -27,7 +27,8 @@ Constants.RACING_TIMEOUT = 180 -- 3-minute failsafe
 -- ─── Player / Session ─────────────────────────────────────────────────────────
 Constants.MAX_PLAYERS    = 10
 Constants.SKIN_COUNT     = 10   -- must match ServerStorage/CharacterSkins count
-Constants.MIN_TO_START   = 2    -- minimum players before LOBBY ends
+Constants.MIN_TO_START   = 1    -- minimum players before LOBBY ends (1 = solo test OK)
+Constants.SOLO_TEST_MODE = true  -- set false in production; skips lobby wait
 
 -- ─── Inventory ────────────────────────────────────────────────────────────────
 Constants.INVENTORY_SIZE       = 8

--- a/roblox/ServerScriptService/GameManager.server.lua
+++ b/roblox/ServerScriptService/GameManager.server.lua
@@ -56,7 +56,16 @@ end
 
 local function _startLobby()
 	_transition(Constants.PHASES.LOBBY)
-	-- Wait for minimum players or a hard timeout (30s)
+
+	if Constants.SOLO_TEST_MODE then
+		-- In test mode: start immediately once at least 1 player is in
+		repeat task.wait(0.5) until #Players:GetPlayers() >= 1
+		task.wait(2)   -- brief 2s so LobbyUI is visible
+		_startFarming()
+		return
+	end
+
+	-- Production: wait for MIN_TO_START or 30s timeout
 	local waited = 0
 	repeat
 		task.wait(1)

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -379,7 +379,7 @@ local function _setupFinishLine()
 					player.Name, #_finishOrder, elapsed))
 
 				-- All racers done?
-				if #_finishOrder >= _totalRacers then
+				if #_finishOrder >= math.max(1, _totalRacers) then
 					_active = false
 					GameManager.raceComplete(_finishOrder)
 				end


### PR DESCRIPTION
## Summary
Studio에서 혼자 테스트할 수 있도록 수정. 10명 필요 없음.

## 변경 사항
- `Constants.SOLO_TEST_MODE = true` 플래그 추가
- `MIN_TO_START = 1`로 변경
- GameManager: 테스트 모드에서 1명 접속 즉시 2초 후 게임 시작
- RacingManager: 솔로 플레이 완주 처리 버그 수정

## 프로덕션 배포 시
`Constants.lua`에서 `SOLO_TEST_MODE = false`로 바꾸면 됨.

## Test plan
- [ ] Studio Play 버튼 → 2초 후 FARMING 페이즈 시작 확인
- [ ] 파밍 → 크래프팅 → 레이싱 → 결과 전체 루프 솔로 완주 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)