### PR TITLE
fix: pickup key SPACE -> E, add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,148 @@
+# Catastrophic Day
+
+A competitive multiplayer racing game for Roblox (up to 10 players) built with Luau and Rojo.
+Each round cycles through three phases: Farming, Crafting, and Racing.
+
+---
+
+## Game Loop
+
+1. **Farming** (90 seconds) -- Collect items scattered across the biome map.
+   Items have four rarity tiers (Common, Uncommon, Rare, Epic) with distinct visual effects.
+   Players can contest item pickups or attempt to steal from each other's inventory.
+
+2. **Crafting** (120 seconds) -- Assign collected items to six vehicle slots:
+   BODY, ENGINE, SPECIAL, MOBILITY (biome-specific), HEAD, and TAIL.
+   Stats are computed server-side based on slot assignments, item rarity, and biome affinity.
+
+3. **Racing** -- Drive the assembled vehicle to the finish line.
+   Each biome has unique physics: mud drag (Forest), buoyancy (Ocean), or updraft zones (Sky).
+   Boost pads, obstacles, and drift corners add moment-to-moment decisions.
+
+---
+
+## Controls
+
+### Farming
+| Key | Action |
+|-----|--------|
+| E (tap) | Pick up nearby item / mash during contest |
+| E (hold 0.9s) | Attempt to steal from nearby player |
+| E (tap x3 quickly) | Defend against steal attempt |
+| Q (hold) | Open emote menu |
+
+### Crafting
+| Input | Action |
+|-------|--------|
+| Click and drag | Place item into a vehicle slot |
+| Click occupied slot | Remove assigned item |
+| COMBINE button | Submit vehicle and lock in stats |
+
+### Racing
+| Key | Action |
+|-----|--------|
+| W / Up | Accelerate |
+| S / Down | Brake / reverse |
+| A / D or Left / Right | Steer |
+| Shift | Activate boost (cooldown: 5s) |
+| E | Use item ability |
+
+---
+
+## Biomes
+
+| Biome | Vehicle | Unique Mechanic |
+|-------|---------|-----------------|
+| Forest | Car | Mud zones (50% speed reduction), drift corners |
+| Ocean | Boat | Buoyancy physics, floating dock track |
+| Sky | Flying vehicle | Updraft zones, kill plane respawn |
+
+---
+
+## Project Structure
+
+```
+roblox/
+  ServerScriptService/
+    GameManager.server.lua          -- Master state machine (Lobby -> Farming -> Crafting -> Racing -> Results)
+    SessionManager.server.lua       -- Player join/leave, data storage
+    FarmingManager.server.lua       -- Item spawning, pickup authority, contest, steal
+    CraftingManager.server.lua      -- Slot validation, vehicle stat calculation
+    RacingManager.server.lua        -- Race state, biome physics, finish detection
+    CharacterManager.server.lua     -- Skin assignment, spawn placement
+    BalanceAudit.server.lua         -- Stat matrix audit (runs only in SOLO_TEST_MODE)
+    MapBuilders/
+      ForestMapBuilder.server.lua
+      OceanMapBuilder.server.lua
+      SkyMapBuilder.server.lua
+      TerrainPainter.server.lua
+    Modules/
+      BiomeConfig.lua
+      ItemConfig.lua                -- 37 items with stats, slot type, rarity, icon
+      ItemModelBuilder.lua          -- Procedural 3D item models
+      ItemVisualUpgrader.lua        -- Rarity glow, particles, idle animation
+      CharacterConfig.lua           -- 10 skin definitions
+  StarterPlayer/StarterPlayerScripts/
+    FarmingClient.client.lua
+    RacingClient.client.lua
+    SoundClient.client.lua
+  StarterGui/
+    HUD/                            -- Race position, boost bar, speedometer
+    FarmingUI/                      -- 8-slot inventory display
+    CraftingUI/                     -- Slot drag-and-drop interface
+    LobbyUI/                        -- Player list, biome reveal
+    EmoteUI/                        -- Q-hold radial menu
+    ResultsUI/                      -- Podium and leaderboard
+    TutorialUI/                     -- Phase key guide (F1 to toggle)
+  ReplicatedStorage/
+    RemoteEvents/                   -- All server <-> client events
+    Shared/
+      Constants.lua                 -- All numeric constants and flags
+      ItemConfig.lua
+      VehicleStats.lua              -- Pure stat calculation functions
+      SoundConfig.lua               -- BGM, ambience, SFX asset ID table
+```
+
+---
+
+## Development Setup
+
+### Requirements
+- [Rojo 7.6.1](https://github.com/rojo-rbx/rojo/releases) (file sync to Studio)
+- Roblox Studio
+- [GitHub CLI](https://cli.github.com/) (for issue/PR workflow)
+
+### Sync to Studio
+
+1. Start the Rojo server:
+   ```
+   rojo serve roblox
+   ```
+2. In Roblox Studio, open the Rojo plugin panel and click **Connect**.
+3. All Lua source files under `roblox/` sync live to the corresponding Studio locations.
+
+### Solo Testing
+
+`Constants.SOLO_TEST_MODE = true` (default) starts the game 2 seconds after one player connects,
+skipping the lobby wait. Set to `false` before production deployment.
+
+---
+
+## Rarity System
+
+| Tier | Spawn share | Stat multiplier | Visual |
+|------|-------------|-----------------|--------|
+| Common | 60% | 1.0x | Plain white |
+| Uncommon | 25% | 1.3x | Green glow ring |
+| Rare | 12% | 1.6x | Blue glow + particles |
+| Epic | 3% | 2.0x | Purple glow + particles + 3 orbiting orbs |
+
+Epic items also gain 1.3x ability duration, 1.2x ability radius, and 0.8x cooldown.
+
+---
+
+## Sound
+
+All audio asset IDs are stored in `ReplicatedStorage/Shared/SoundConfig.lua`.
+Replace the placeholder IDs with real Roblox free audio IDs from the Toolbox before publishing.
+The `SoundClient` handles BGM fading between phases and SFX routing for all game events.

--- a/roblox/StarterGui/TutorialUI/init.client.lua
+++ b/roblox/StarterGui/TutorialUI/init.client.lua
@@ -27,9 +27,9 @@ local PHASE_GUIDES = {
 		title = "🌾  FARMING PHASE",
 		colour = Color3.fromRGB(80, 180, 60),
 		keys = {
-			{ key = "SPACE",        desc = "아이템 줍기 / 경쟁 연타" },
-			{ key = "SPACE (길게)", desc = "인벤토리 도둑질 시도 (0.9초)" },
-			{ key = "SPACE (빠르게×3)", desc = "도둑질 방어" },
+			{ key = "E",        desc = "아이템 줍기 / 경쟁 연타" },
+			{ key = "E (길게)", desc = "인벤토리 도둑질 시도 (0.9초)" },
+			{ key = "E (빠르게×3)", desc = "도둑질 방어" },
 			{ key = "Q (길게)",     desc = "이모트 메뉴 열기" },
 		},
 		tip = "아이콘과 이름이 표시된 아이템을 수집하세요!\n희귀도: 회색(Common) < 초록(Uncommon) < 파랑(Rare) < 보라(Epic)",

--- a/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
@@ -112,7 +112,7 @@ local function _showPrompt(part)
 	local label = Instance.new("TextLabel")
 	label.Size            = UDim2.fromScale(1, 1)
 	label.BackgroundTransparency = 1
-	label.Text            = "[SPACE] Pick Up"
+	label.Text            = "[E] Pick Up"
 	label.TextColor3      = Color3.new(1, 1, 1)
 	label.TextScaled      = true
 	label.Font            = Enum.Font.GothamBold
@@ -138,12 +138,12 @@ local function _flashPromptDenied()
 	end)
 end
 
--- ─── SPACE handler ────────────────────────────────────────────────────────────
+-- ─── E handler ────────────────────────────────────────────────────────────
 
 UserInputService.InputBegan:Connect(function(input, processed)
 	if processed or not _enabled then return end
 
-	if input.KeyCode == Enum.KeyCode.Space then
+	if input.KeyCode == Enum.KeyCode.E then
 		if _contestItemId then
 			-- We're in a contest — count presses
 			_contestPresses = _contestPresses + 1
@@ -168,21 +168,21 @@ UserInputService.InputBegan:Connect(function(input, processed)
 	end
 end)
 
--- Long-press SPACE for steal (hold ~1s near another player)
-local _spaceHoldStart = nil
+-- Long-press E for steal (hold ~0.9s near another player)
+local _eHoldStart = nil
 UserInputService.InputBegan:Connect(function(input, processed)
 	if processed or not _enabled then return end
-	if input.KeyCode == Enum.KeyCode.Space and _nearestPlayer and not _nearestItem then
-		_spaceHoldStart = tick()
+	if input.KeyCode == Enum.KeyCode.E and _nearestPlayer and not _nearestItem then
+		_eHoldStart = tick()
 	end
 end)
 
 UserInputService.InputEnded:Connect(function(input)
-	if input.KeyCode == Enum.KeyCode.Space then
-		if _spaceHoldStart and (tick() - _spaceHoldStart) >= 0.9 and _nearestPlayer then
+	if input.KeyCode == Enum.KeyCode.E then
+		if _eHoldStart and (tick() - _eHoldStart) >= 0.9 and _nearestPlayer then
 			RemoteEvents.RequestSteal:InvokeServer(_nearestPlayer.UserId)
 		end
-		_spaceHoldStart = nil
+		_eHoldStart = nil
 	end
 end)
 
@@ -211,14 +211,14 @@ end)
 
 RemoteEvents.StealAttempt.OnClientEvent:Connect(function(thiefName)
 	-- Show defend UI
-	print(string.format("[Steal] %s is trying to steal from you! Press SPACE x3!", thiefName))
+	print(string.format("[Steal] %s is trying to steal from you! Press E x3!", thiefName))
 	-- TODO: proper ScreenGui overlay (Issue #44 / #64 UI)
 	local defendPresses = 0
 	local defended = false
 	local conn
 	conn = UserInputService.InputBegan:Connect(function(input, processed)
 		if processed then return end
-		if input.KeyCode == Enum.KeyCode.Space then
+		if input.KeyCode == Enum.KeyCode.E then
 			defendPresses = defendPresses + 1
 			if defendPresses >= Constants.STEAL_DEFEND_PRESSES then
 				defended = true


### PR DESCRIPTION
## Summary
- SPACE is reserved for jump in Roblox — all farming interactions moved to E key
- TutorialUI key guide updated to match
- README.md added with full project overview, controls table, biome table, file structure, setup instructions, and rarity/sound notes

## Test plan
- [ ] Press E near an item — should show pickup and give item
- [ ] Press E rapidly during a contest — press count increments
- [ ] Hold E near another player (no item nearby) — steal attempt fires after 0.9s
- [ ] Press E 3x quickly during steal defend window — defend succeeds
- [ ] SPACE / jump still works normally (no conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)