### PR TITLE
fix: item parts falling + Racing HUD during Farming + add FarmingUI

### DIFF
--- a/roblox/ServerScriptService/Modules/ItemModelBuilder.lua
+++ b/roblox/ServerScriptService/Modules/ItemModelBuilder.lua
@@ -972,9 +972,9 @@ function ItemModelBuilder.build(itemName, parent)
 
 	local primary = builder(model)
 	model.PrimaryPart = primary
-	model.Parent = parent
 
-	-- Weld all loose parts to primary
+	-- Weld all loose parts BEFORE parenting to world so physics never sees
+	-- unanchored, un-welded parts (they would fall through the floor otherwise).
 	for _, part in ipairs(model:GetDescendants()) do
 		if part:IsA("BasePart") and part ~= primary then
 			local hasWeld = false
@@ -989,6 +989,9 @@ function ItemModelBuilder.build(itemName, parent)
 			if not hasWeld then _w(model, primary, part) end
 		end
 	end
+
+	-- Parent after welds are set so the simulation starts with everything locked.
+	model.Parent = parent
 
 	return model
 end

--- a/roblox/StarterGui/FarmingUI/init.client.lua
+++ b/roblox/StarterGui/FarmingUI/init.client.lua
@@ -1,0 +1,188 @@
+-- FarmingUI/init.client.lua
+-- Farming phase overlay: countdown timer + 8-slot inventory bar.
+-- Resolves: Issue #41 (Farming HUD)
+
+local Players           = game:GetService("Players")
+local RunService        = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Constants    = require(ReplicatedStorage.Shared.Constants)
+local RemoteEvents = require(ReplicatedStorage.RemoteEvents)
+local LocalPlayer  = Players.LocalPlayer
+
+-- ─── Screen ───────────────────────────────────────────────────────────────────
+
+local screen = Instance.new("ScreenGui")
+screen.Name           = "FarmingUI"
+screen.ResetOnSpawn   = false
+screen.IgnoreGuiInset = true
+screen.Enabled        = false
+screen.Parent         = LocalPlayer.PlayerGui
+
+-- ─── Timer bar (top center) ──────────────────────────────────────────────────
+
+local timerBg = Instance.new("Frame")
+timerBg.Name             = "TimerBg"
+timerBg.Size             = UDim2.new(0, 260, 0, 46)
+timerBg.Position         = UDim2.new(0.5, -130, 0, 14)
+timerBg.BackgroundColor3 = Color3.fromRGB(10, 10, 20)
+timerBg.BackgroundTransparency = 0.25
+timerBg.BorderSizePixel  = 0
+timerBg.Parent           = screen
+
+local _tc = Instance.new("UICorner"); _tc.CornerRadius = UDim.new(0, 10); _tc.Parent = timerBg
+
+local timerLabel = Instance.new("TextLabel")
+timerLabel.Name            = "TimerLabel"
+timerLabel.Size            = UDim2.new(1, 0, 0.5, 0)
+timerLabel.Position        = UDim2.new(0, 0, 0, 0)
+timerLabel.BackgroundTransparency = 1
+timerLabel.Text            = "FARMING  1:30"
+timerLabel.Font            = Enum.Font.GothamBold
+timerLabel.TextScaled      = true
+timerLabel.TextColor3      = Color3.fromRGB(80, 220, 80)
+timerLabel.Parent          = timerBg
+
+local phaseLabel = Instance.new("TextLabel")
+phaseLabel.Name            = "PhaseLabel"
+phaseLabel.Size            = UDim2.new(1, 0, 0.5, 0)
+phaseLabel.Position        = UDim2.new(0, 0, 0.5, 0)
+phaseLabel.BackgroundTransparency = 1
+phaseLabel.Text            = "아이템을 수집하세요!  [E] 줍기"
+phaseLabel.Font            = Enum.Font.Gotham
+phaseLabel.TextScaled      = true
+phaseLabel.TextColor3      = Color3.fromRGB(200, 200, 200)
+phaseLabel.Parent          = timerBg
+
+-- ─── Inventory bar (bottom center) ───────────────────────────────────────────
+
+local invBg = Instance.new("Frame")
+invBg.Name             = "InventoryBar"
+invBg.Size             = UDim2.new(0, 8 * 60 + 18, 0, 64)
+invBg.Position         = UDim2.new(0.5, -(8 * 60 + 18) / 2, 1, -82)
+invBg.BackgroundColor3 = Color3.fromRGB(10, 10, 20)
+invBg.BackgroundTransparency = 0.25
+invBg.BorderSizePixel  = 0
+invBg.Parent           = screen
+
+local _ic = Instance.new("UICorner"); _ic.CornerRadius = UDim.new(0, 10); _ic.Parent = invBg
+
+local invLayout = Instance.new("UIListLayout")
+invLayout.FillDirection  = Enum.FillDirection.Horizontal
+invLayout.VerticalAlignment = Enum.VerticalAlignment.Center
+invLayout.HorizontalAlignment = Enum.HorizontalAlignment.Center
+invLayout.Padding        = UDim.new(0, 4)
+invLayout.Parent         = invBg
+
+local slots = {}
+for i = 1, Constants.INVENTORY_SIZE do
+	local slot = Instance.new("Frame")
+	slot.Name              = "Slot" .. i
+	slot.Size              = UDim2.new(0, 54, 0, 54)
+	slot.BackgroundColor3  = Color3.fromRGB(35, 35, 50)
+	slot.BorderSizePixel   = 0
+	slot.Parent            = invBg
+
+	local _sc = Instance.new("UICorner"); _sc.CornerRadius = UDim.new(0, 6); _sc.Parent = slot
+
+	local icon = Instance.new("TextLabel")
+	icon.Name              = "Icon"
+	icon.Size              = UDim2.new(1, 0, 0.58, 0)
+	icon.BackgroundTransparency = 1
+	icon.Text              = ""
+	icon.Font              = Enum.Font.GothamBold
+	icon.TextScaled        = true
+	icon.TextColor3        = Color3.new(1, 1, 1)
+	icon.Parent            = slot
+
+	local name = Instance.new("TextLabel")
+	name.Name              = "ItemName"
+	name.Size              = UDim2.new(1, 0, 0.42, 0)
+	name.Position          = UDim2.new(0, 0, 0.58, 0)
+	name.BackgroundTransparency = 1
+	name.Text              = ""
+	name.Font              = Enum.Font.Gotham
+	name.TextScaled        = true
+	name.TextColor3        = Color3.fromRGB(180, 180, 180)
+	name.Parent            = slot
+
+	slots[i] = slot
+end
+
+-- ─── Inventory update ─────────────────────────────────────────────────────────
+
+local ItemConfig = require(ReplicatedStorage.Shared.ItemConfig)
+
+local RARITY_COLOUR = {
+	Common   = Color3.fromRGB(200, 200, 200),
+	Uncommon = Color3.fromRGB(80,  200, 80),
+	Rare     = Color3.fromRGB(100, 160, 255),
+	Epic     = Color3.fromRGB(200, 100, 255),
+}
+
+local function _updateSlots(inventory)
+	for i = 1, Constants.INVENTORY_SIZE do
+		local slot = slots[i]
+		local itemName = inventory[i]
+		if itemName then
+			local cfg = ItemConfig[itemName]
+			slot:FindFirstChild("Icon").Text     = (cfg and cfg.icon) or "?"
+			slot:FindFirstChild("ItemName").Text = itemName
+			slot:FindFirstChild("ItemName").TextColor3 =
+				RARITY_COLOUR[(cfg and cfg.rarity) or "Common"]
+			slot.BackgroundColor3 = Color3.fromRGB(45, 45, 65)
+		else
+			slot:FindFirstChild("Icon").Text     = ""
+			slot:FindFirstChild("ItemName").Text = ""
+			slot.BackgroundColor3 = Color3.fromRGB(35, 35, 50)
+		end
+	end
+end
+
+RemoteEvents.InventoryUpdated.OnClientEvent:Connect(_updateSlots)
+
+-- ─── Timer countdown ─────────────────────────────────────────────────────────
+
+local _startTick   = 0
+local _runConn     = nil
+local _totalTime   = Constants.PHASE_DURATION.FARMING
+
+local function _startTimer()
+	_startTick = tick()
+	if _runConn then _runConn:Disconnect() end
+	_runConn = RunService.Heartbeat:Connect(function()
+		if not screen.Enabled then return end
+		local elapsed = tick() - _startTick
+		local remaining = math.max(0, _totalTime - elapsed)
+		local mins = math.floor(remaining / 60)
+		local secs = math.floor(remaining % 60)
+		timerLabel.Text = string.format("FARMING  %d:%02d", mins, secs)
+
+		-- Pulse red in last 15 seconds
+		if remaining <= 15 then
+			local blink = math.floor(remaining * 2) % 2 == 0
+			timerLabel.TextColor3 = blink
+				and Color3.fromRGB(255, 60, 60)
+				or  Color3.fromRGB(255, 180, 60)
+		else
+			timerLabel.TextColor3 = Color3.fromRGB(80, 220, 80)
+		end
+	end)
+end
+
+local function _stopTimer()
+	if _runConn then _runConn:Disconnect(); _runConn = nil end
+end
+
+-- ─── Phase gate ───────────────────────────────────────────────────────────────
+
+RemoteEvents.PhaseChanged.OnClientEvent:Connect(function(phase)
+	if phase == Constants.PHASES.FARMING then
+		_updateSlots({})
+		screen.Enabled = true
+		_startTimer()
+	else
+		screen.Enabled = false
+		_stopTimer()
+	end
+end)

--- a/roblox/StarterGui/HUD/init.client.lua
+++ b/roblox/StarterGui/HUD/init.client.lua
@@ -310,18 +310,20 @@ end
 
 -- ─── Remote listeners ────────────────────────────────────────────────────────
 
+local _cachedBiome = nil
+
 RemoteEvents.PhaseChanged.OnClientEvent:Connect(function(phase)
 	local Constants = require(ReplicatedStorage.Shared.Constants)
 	if phase == Constants.PHASES.RACING then
-		-- biome comes separately via BiomeSelected
-	elseif phase == Constants.PHASES.RESULTS then
+		_enableHUD(_cachedBiome)
+	elseif phase ~= Constants.PHASES.RACING then
 		_disableHUD()
 	end
 end)
 
 RemoteEvents.BiomeSelected.OnClientEvent:Connect(function(biome)
-	-- Will be called before racing starts; cache for when HUD enabled
-	_enableHUD(biome)
+	-- Cache biome; HUD only activates when RACING phase starts.
+	_cachedBiome = biome
 end)
 
 RemoteEvents.VehicleSpawned.OnClientEvent:Connect(function(userId, vehicleModel)


### PR DESCRIPTION
## Summary
- **ItemModelBuilder**: parts were parented to world before WeldConstraints were created, giving physics one frame to drop them through the floor. Now all welds are set up first, then the model is parented.
- **HUD**: `BiomeSelected` incorrectly called `_enableHUD()`, so the Racing overlay (BOOST bar, speedometer) was showing during Farming phase. Now BiomeSelected only caches the biome; HUD only enables on RACING phase.
- **FarmingUI**: was completely missing. Added countdown timer (90s, red pulse last 15s) + 8-slot inventory bar with emoji icons and rarity-colored names.

## Test plan
- [ ] Items spawn with full 3D shape — no flat parts through the floor
- [ ] No BOOST bar / speedometer visible during Farming phase
- [ ] Top-center timer counts down from 1:30 during Farming
- [ ] Inventory bar updates when items are picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)