### PR TITLE
fix(#99): phase UI race condition + pine tree canopy position

### DIFF
--- a/roblox/ServerScriptService/GameManager.lua
+++ b/roblox/ServerScriptService/GameManager.lua
@@ -58,9 +58,11 @@ local function _startLobby()
 	_transition(Constants.PHASES.LOBBY)
 
 	if Constants.SOLO_TEST_MODE then
-		-- In test mode: start immediately once at least 1 player is in
+		-- In test mode: start immediately once at least 1 player is in.
+		-- Wait 5s (up from 2s) so the client's character has time to load and
+		-- StarterGui scripts can connect their PhaseChanged listeners before we fire.
 		repeat task.wait(0.5) until #Players:GetPlayers() >= 1
-		task.wait(2)   -- brief 2s so LobbyUI is visible
+		task.wait(5)
 		_startFarming()
 		return
 	end

--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -549,10 +549,11 @@ local function _buildTrees(root)
 			Material = MAT.WOOD,
 			CanCollide = false,
 		})
-		-- 3-layer cone canopy
+		-- 3-layer cone canopy stacked at the UPPER portion of the trunk.
+		-- Layer 0 (largest, bottom) at 65%, layer 1 at 80%, layer 2 (smallest, tip) at 95%.
 		for layer = 0, 2 do
 			local layerR = (3 - layer) * 2.5
-			local layerY = h * 0.45 + layer * h * 0.18
+			local layerY = h * (0.65 + layer * 0.15)  -- 65%, 80%, 95% of trunk height
 			_part(parent, {
 				Name     = "PineLeaf",
 				Size     = Vector3.new(layerR * 2, layerR * 0.9, layerR * 2),

--- a/roblox/ServerScriptService/SessionManager.lua
+++ b/roblox/ServerScriptService/SessionManager.lua
@@ -102,7 +102,8 @@ local function _onPlayerAdded(player)
 
 	print(string.format("[SessionManager] %s joined → skin #%d", player.Name, skinIndex))
 
-	-- If mid-game, send current phase immediately
+	-- If mid-game, send current phase immediately (handles rejoins, but client
+	-- scripts may not be connected yet on first join — handled by CharacterAdded below)
 	local phase = GameManager.getPhase()
 	if phase ~= Constants.PHASES.LOBBY then
 		RemoteEvents.PhaseChanged:FireClient(player, phase)
@@ -111,6 +112,20 @@ local function _onPlayerAdded(player)
 			RemoteEvents.BiomeSelected:FireClient(player, biome)
 		end
 	end
+
+	-- Re-send phase on every character load so StarterGui scripts (which run
+	-- after the character spawns) reliably receive the current phase.
+	-- Without this, clients miss PhaseChanged on first join if FARMING starts
+	-- before their character has loaded and connected event listeners.
+	player.CharacterAdded:Connect(function()
+		task.wait(0.5)  -- allow StarterGui LocalScripts to connect their OnClientEvent
+		local currentPhase = GameManager.getPhase()
+		RemoteEvents.PhaseChanged:FireClient(player, currentPhase)
+		local currentBiome = GameManager.getBiome()
+		if currentBiome then
+			RemoteEvents.BiomeSelected:FireClient(player, currentBiome)
+		end
+	end)
 end
 
 -- ─── Leave handler ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause
`PhaseChanged` was fired when the player joined, before their character loaded and before StarterGui `LocalScript`s had connected their `OnClientEvent` handlers. The 2-second `SOLO_TEST_MODE` wait was also insufficient for slower loads.

## Changes

### SessionManager — CharacterAdded re-send
Every time a player's character loads (which triggers StarterGui scripts to run), re-fire the current `phase` and `biome` to that client after a 0.5 s grace period. This is the reliable moment when all client-side event listeners are connected.

### GameManager — longer SOLO_TEST_MODE wait
Increased from 2 s → 5 s before `_startFarming()` is called in solo/test mode, reducing the chance of the server advancing before the client is ready.

### ForestMapBuilder — pine tree canopy
- **Before**: `layerY = h * 0.45 + layer * h * 0.18` → all three canopy layers were inside the trunk (45–81% of height), canopy appeared floating/separated from the crown
- **After**: `layerY = h * (0.65 + layer * 0.15)` → layers at 65 / 80 / 95% of trunk height, canopy correctly at the treetop

## Test plan
- [ ] Solo test in Studio: confirm FarmingUI appears within ~5 s of joining
- [ ] Wait for farming timer (90 s) — confirm CraftingUI appears without manual intervention
- [ ] Rejoin mid-game during CRAFTING/RACING — confirm correct UI shows within 0.5 s of character load
- [ ] Check Forest map — confirm pine trees show layered cone canopy at treetop, not embedded in trunk

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)