### PR TITLE
fix(#103-107): crafting freeze, race spawn, UI layout, vehicle controls

### DIFF
--- a/roblox/ServerScriptService/CharacterManager.server.lua
+++ b/roblox/ServerScriptService/CharacterManager.server.lua
@@ -170,14 +170,35 @@ end
 
 local GameManager = require(ServerScriptService.GameManager)
 
+local function _setMovement(player, enabled)
+	local char = player.Character
+	local hum  = char and char:FindFirstChildOfClass("Humanoid")
+	if not hum then return end
+	hum.WalkSpeed  = enabled and 16 or 0
+	hum.JumpHeight = enabled and 7.2 or 0
+end
+
 GameManager.onPhaseChanged(function(phase, biome)
 	if phase == Constants.PHASES.FARMING then
 		_spawnIndex = 0
 		task.wait(0.5)  -- small grace period after phase change
 		for _, player in ipairs(Players:GetPlayers()) do
+			_setMovement(player, true)
 			if player.Character then
 				_teleportToFarm(player, biome)
 			end
+		end
+
+	elseif phase == Constants.PHASES.CRAFTING then
+		-- Freeze all characters so players can't walk around during modal
+		for _, player in ipairs(Players:GetPlayers()) do
+			_setMovement(player, false)
+		end
+
+	elseif phase == Constants.PHASES.RACING then
+		-- Restore movement (vehicle controls take over, but humanoid should not be frozen)
+		for _, player in ipairs(Players:GetPlayers()) do
+			_setMovement(player, true)
 		end
 	end
 end)

--- a/roblox/ServerScriptService/CraftingManager.server.lua
+++ b/roblox/ServerScriptService/CraftingManager.server.lua
@@ -150,13 +150,26 @@ GameManager.onPhaseChanged(function(phase, biome)
 				if model then
 					model.Parent = game.Workspace
 					SessionManager.setVehicle(player, model, stats)
-					RemoteEvents.VehicleSpawned:FireAllClients(player.UserId, model)
 
-					-- Seat player
+					-- Give the model one frame to replicate before firing the client
+					-- event and before calling :Sit(), otherwise the client receives
+					-- a model reference it hasn't loaded yet and seat physics are wrong.
+					task.wait()
+
 					local seat = model:FindFirstChildWhichIsA("VehicleSeat", true)
-					if seat and player.Character then
-						seat:Sit(player.Character:FindFirstChild("Humanoid"))
+					if seat then
+						print(string.format("[CraftingManager] Vehicle for %s spawned at %s | seat=%s",
+							player.Name, tostring(model.PrimaryPart and model.PrimaryPart.Position), tostring(seat)))
+						RemoteEvents.VehicleSpawned:FireClient(player, player.UserId, model)
+						if player.Character then
+							seat:Sit(player.Character:FindFirstChild("Humanoid"))
+						end
+					else
+						warn("[CraftingManager] No VehicleSeat found in vehicle for", player.Name)
+						RemoteEvents.VehicleSpawned:FireClient(player, player.UserId, model)
 					end
+				else
+					warn("[CraftingManager] VehicleBuilder.build returned nil for", player.Name)
 				end
 			end
 		end)

--- a/roblox/ServerScriptService/CraftingManager.server.lua
+++ b/roblox/ServerScriptService/CraftingManager.server.lua
@@ -13,6 +13,7 @@ local ItemConfig     = require(ServerScriptService.Modules.ItemConfig)
 local VehicleStats   = require(ReplicatedStorage.Shared.VehicleStats)
 local GameManager    = require(ServerScriptService.GameManager)
 local SessionManager = require(ServerScriptService.SessionManager)
+local BiomeConfig    = require(ServerScriptService.Modules.BiomeConfig)
 
 -- ─── State ────────────────────────────────────────────────────────────────────
 
@@ -133,7 +134,7 @@ GameManager.onPhaseChanged(function(phase, biome)
 		-- Spawn vehicles for all players
 		task.spawn(function()
 			local VehicleBuilder = require(ServerScriptService.Modules.VehicleBuilder)
-			local spawnGrid = _buildSpawnGrid()
+			local spawnGrid = _buildSpawnGrid(biome)
 
 			for i, player in ipairs(Players:GetPlayers()) do
 				local data = SessionManager.getData(player)
@@ -164,15 +165,20 @@ end)
 
 -- ─── Build race start grid ────────────────────────────────────────────────────
 
-function _buildSpawnGrid()
-	-- 2 rows of 5, staggered 6 studs apart, at track start (Z = +550)
+function _buildSpawnGrid(biome)
+	local cfg  = biome and BiomeConfig[biome]
+	local startZ = (cfg and cfg.raceStartZ) or 195
+	local startY = (cfg and cfg.raceStartY) or 2
+
+	-- 2 rows of 5, staggered 8 studs apart, pointing down-Z (race direction)
 	local grid = {}
 	for i = 1, Constants.MAX_PLAYERS do
 		local row = math.ceil(i / 5)
 		local col = ((i - 1) % 5) + 1
 		local x   = (col - 3) * 7
-		local z   = 550 - (row - 1) * 10
-		table.insert(grid, CFrame.new(x, 2, z))
+		local z   = startZ + (row - 1) * 8  -- row 1 at startZ, row 2 slightly behind
+		table.insert(grid, CFrame.new(x, startY, z))
 	end
+	print(string.format("[CraftingManager] Race spawn grid: biome=%s startZ=%d startY=%d", tostring(biome), startZ, startY))
 	return grid
 end

--- a/roblox/ServerScriptService/Modules/BiomeConfig.lua
+++ b/roblox/ServerScriptService/Modules/BiomeConfig.lua
@@ -10,6 +10,8 @@ BiomeConfig["FOREST"] = {
 	mapPath        = "Workspace.Maps.ForestMap",
 	vehicleType    = "Car",
 	mobilitySlot   = "WHEELS",
+	raceStartZ     = 195,   -- just before track node[1] at Z=175
+	raceStartY     = 2,
 	skyboxId       = "rbxassetid://0",          -- TODO: replace with asset IDs
 	ambientSoundId = "rbxassetid://0",          -- TODO
 
@@ -37,6 +39,8 @@ BiomeConfig["OCEAN"] = {
 	mapPath        = "Workspace.Maps.OceanMap",
 	vehicleType    = "Boat",
 	mobilitySlot   = "SAIL",
+	raceStartZ     = 175,   -- just before dock node[1] at Z=155
+	raceStartY     = 3,     -- WATER_Y(0) + dock(1.5) + clearance(1.5)
 	skyboxId       = "rbxassetid://0",
 	ambientSoundId = "rbxassetid://0",
 
@@ -65,6 +69,8 @@ BiomeConfig["SKY"] = {
 	mapPath        = "Workspace.Maps.SkyMap",
 	vehicleType    = "FlyingVehicle",
 	mobilitySlot   = "WINGS",
+	raceStartZ     = 225,   -- just before platform[1] center at Z=200
+	raceStartY     = 84,    -- SKY_BASE_Y(80) + platform top(4)
 	skyboxId       = "rbxassetid://0",
 	ambientSoundId = "rbxassetid://0",
 

--- a/roblox/ServerScriptService/Modules/VehicleBuilder.lua
+++ b/roblox/ServerScriptService/Modules/VehicleBuilder.lua
@@ -443,14 +443,19 @@ function VehicleBuilder.build(stats, biome, spawnCFrame, slots)
 		primaryPart = buildCar(model, stats, palette, slots)
 	end
 
-	-- Weld all loose parts to chassis
+	-- Weld all loose parts to chassis; only chassis keeps CanCollide=true.
+	-- Cabin, decorations, and VehicleSeat must be non-collidable so the
+	-- player character can sit without being trapped inside geometry.
 	for _, part in ipairs(model:GetDescendants()) do
-		if part:IsA("BasePart") and part ~= primaryPart then
-			local hasWeld = false
-			for _, c in ipairs(part:GetChildren()) do
-				if c:IsA("WeldConstraint") then hasWeld = true; break end
+		if part:IsA("BasePart") then
+			if part ~= primaryPart then
+				part.CanCollide = false
+				local hasWeld = false
+				for _, c in ipairs(part:GetChildren()) do
+					if c:IsA("WeldConstraint") then hasWeld = true; break end
+				end
+				if not hasWeld then weld(primaryPart, part) end
 			end
-			if not hasWeld then weld(primaryPart, part) end
 		end
 	end
 

--- a/roblox/StarterGui/CraftingUI/init.client.lua
+++ b/roblox/StarterGui/CraftingUI/init.client.lua
@@ -25,8 +25,8 @@ screen.Parent         = LocalPlayer.PlayerGui
 
 local panel = Instance.new("Frame")
 panel.Name                  = "Panel"
-panel.Size                  = UDim2.new(0, 500, 0, 430)
-panel.Position              = UDim2.new(0.5, -250, 0.5, -215)
+panel.Size                  = UDim2.new(0, 480, 0, 430)
+panel.Position              = UDim2.new(0, 20, 0.5, -215)
 panel.BackgroundColor3      = Color3.fromRGB(10, 10, 22)
 panel.BackgroundTransparency = 0.12
 panel.BorderSizePixel       = 0

--- a/roblox/StarterGui/TutorialUI/init.client.lua
+++ b/roblox/StarterGui/TutorialUI/init.client.lua
@@ -241,7 +241,7 @@ end
 local refPanel = Instance.new("Frame")
 refPanel.Name             = "ReferencePanel"
 refPanel.Size             = UDim2.new(0, 440, 0, 0)
-refPanel.Position         = UDim2.new(0.5, -220, 0.5, 0)
+refPanel.Position         = UDim2.new(1, -460, 0.5, 0)
 refPanel.AnchorPoint      = Vector2.new(0, 0.5)
 refPanel.BackgroundColor3 = Color3.fromRGB(12, 12, 22)
 refPanel.BackgroundTransparency = 0.05

--- a/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
@@ -155,13 +155,18 @@ UserInputService.InputBegan:Connect(function(input, processed)
 		if _nearestItem then
 			local idVal  = _nearestItem:FindFirstChild("ItemId")
 			local itemId = idVal and idVal.Value
-			if not itemId then return end
+			if not itemId then
+				warn("[FarmingClient] E pressed but ItemId missing on:", _nearestItem.Name)
+				return
+			end
 			local result = RemoteEvents.RequestPickup:InvokeServer(itemId)
+			print("[FarmingClient] RequestPickup result:", result)
 			if result == "ok" then
 				_hidePrompt()
 				_nearestItem = nil
 			elseif result == "contested" then
-				_contestItemId  = tostring(_nearestItem)
+				local idv = _nearestItem and _nearestItem:FindFirstChild("ItemId")
+				_contestItemId  = idv and idv.Value or tostring(_nearestItem)
 				_contestPresses = 1
 			else
 				_flashPromptDenied()


### PR DESCRIPTION
## Summary

- **#104** CharacterManager: CRAFTING 페이즈 진입 시 Humanoid.WalkSpeed=0/JumpHeight=0으로 이동 잠금, FARMING/RACING 복원
- **#105** CraftingUI를 왼쪽(X=20)으로 이동, TutorialUI refPanel을 오른쪽(X=1,-460)으로 이동 → crafting 중 두 UI 겹침 해결
- **#106** BiomeConfig에 raceStartZ/Y 추가 (FOREST Z=195, OCEAN Z=175, SKY Z=225). CraftingManager 스폰 그리드를 biome-aware하게 수정. 기존 Z=550 하드코딩 제거
- **#107** VehicleBuilder: chassis 외 모든 파트(cabin, seat 포함) CanCollide=false 처리. 기존 CanCollide=true로 인해 character가 cabin 안에 갇혀 VehicleSeat 물리 미작동
- **#103** FarmingClient: E키 RequestPickup 결과 print/warn 추가 (ItemId 미존재 시 warn)
- CraftingManager: seat:Sit() 전 task.wait()로 replication 대기, FireClient로 변경, 디버그 출력 추가

## Test plan

- [ ] CRAFTING 페이즈에서 캐릭터 이동 불가 확인
- [ ] CraftingUI(왼쪽)와 TutorialUI(오른쪽)이 겹치지 않음 확인
- [ ] RACING 페이즈에서 vehicle이 race track 입구에 스폰 확인
- [ ] WASD/화살표키로 vehicle 조작 가능 확인
- [ ] FARMING 페이즈에서 E키 픽업 Output 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)