### PR TITLE
feat: drift corners, F-key boost, and biome drift UX for all maps

### DIFF
--- a/roblox/ReplicatedStorage/RemoteEvents/init.lua
+++ b/roblox/ReplicatedStorage/RemoteEvents/init.lua
@@ -19,6 +19,7 @@
 --   EmoteFired          → (userId: number, emoteId: string)
 --   RaceFinished        → (finishOrder: {userId:number, time:number}[])
 --   ScreenEffect        → (effectName: string, params: table) -- client-side VFX
+--   DriftCharge         → (amount: number)  -- boost gauge fill from DriftCorner zone
 --
 -- RemoteFunctions (server-authoritative):
 --   RequestPickup       → itemId: string          → "ok" | "denied: <reason>"
@@ -47,6 +48,7 @@ local EVENTS = {
 	"EmoteFired",
 	"RaceFinished",
 	"ScreenEffect",
+	"DriftCharge",
 }
 
 local FUNCTIONS = {

--- a/roblox/ReplicatedStorage/Shared/Constants.lua
+++ b/roblox/ReplicatedStorage/Shared/Constants.lua
@@ -66,6 +66,12 @@ Constants.BOOST_MULTIPLIER = 1.5
 Constants.BOOST_COOLDOWN   = 5
 Constants.POSITION_SYNC_RATE = 0.5  -- seconds between PlayerPositionSync broadcasts
 
+-- ─── Drift / DriftCorner ──────────────────────────────────────────────────────
+-- Driving through a tagged DriftCorner zone fills the boost gauge by this amount.
+-- Key bindings: Shift = drift slide; F = activate boost when gauge is full.
+Constants.DRIFT_CHARGE_PER_CORNER = 0.5   -- 2 corners = full gauge
+Constants.DRIFT_CORNER_COOLDOWN   = 8     -- seconds before same zone charges again
+
 -- ─── Farming Contest (button-mash) ────────────────────────────────────────────
 Constants.CONTEST_DURATION   = 2.5  -- seconds
 Constants.STEAL_COOLDOWN     = 8    -- seconds between steal attempts

--- a/roblox/ServerScriptService/CharacterManager.server.lua
+++ b/roblox/ServerScriptService/CharacterManager.server.lua
@@ -19,9 +19,9 @@ local SPAWN_SPACING = 8
 
 -- Biome-specific fallback spawn centres (used when no FarmSpawn tags found in map)
 local BIOME_SPAWN_DEFAULTS = {
-	FOREST = Vector3.new(0,  3,  320),
-	OCEAN  = Vector3.new(0,  3,  320),
-	SKY    = Vector3.new(0, 86,  390),  -- matches SkyMapBuilder SKY_BASE_Y + 4.5 + 1.5
+	FOREST = Vector3.new(0,  3,  320),  -- FarmGround top=1, HRP = top+2
+	OCEAN  = Vector3.new(0,  7,  375),  -- FarmGrass top=5 (WATER_Y+2.5+0.5), HRP = top+2; Z=farm center
+	SKY    = Vector3.new(0, 82,  390),  -- FarmPlatform top=80 (SKY_BASE_Y-4.5+4.5), HRP = top+2
 }
 
 -- Returns CFrame array of spawn points for the given biome.

--- a/roblox/ServerScriptService/CraftingManager.server.lua
+++ b/roblox/ServerScriptService/CraftingManager.server.lua
@@ -172,12 +172,15 @@ GameManager.onPhaseChanged(function(phase, biome)
 					if seat then
 						print(string.format("[CraftingManager] Vehicle for %s spawned at %s | seat=%s",
 							player.Name, tostring(primary and primary.Position), tostring(seat)))
-						RemoteEvents.VehicleSpawned:FireClient(player, player.UserId, model)
+						-- Seat player BEFORE firing VehicleSpawned so the drive loop
+						-- starts only after the character is already welded to the seat.
 						if player.Character then
 							seat:Sit(player.Character:FindFirstChild("Humanoid"))
 						end
+						task.wait(0.1)  -- let weld settle
+						RemoteEvents.VehicleSpawned:FireClient(player, player.UserId, model)
 						-- Unanchor after sit takes effect so vehicle can move
-						task.wait(0.2)
+						task.wait(0.1)
 						if primary and primary.Parent then
 							primary.Anchored = false
 						end

--- a/roblox/ServerScriptService/FarmingManager.server.lua
+++ b/roblox/ServerScriptService/FarmingManager.server.lua
@@ -77,8 +77,8 @@ local function _spawnItems(biome)
 	-- Bounding-box inference is unreliable (tall trees skew Y; water planes skew X/Z).
 	local BIOME_ZONES = {
 		FOREST = { cx=0, cz=350, halfX=80, halfZ=120, baseY=2.5 },  -- FarmGround Z:200-500, Y top=1
-		OCEAN  = { cx=0, cz=375, halfX=55, halfZ=90,  baseY=4.5 },  -- FarmIsland Z:250-500, FarmGrass Y top=3
-		SKY    = { cx=0, cz=390, halfX=35, halfZ=70,  baseY=86  },  -- FarmPlatform Z:320-460, Y=84.5+1.5
+		OCEAN  = { cx=0, cz=375, halfX=55, halfZ=90,  baseY=6.5 },  -- FarmIsland Z:250-500, FarmGrass Y top=5.0 (WATER_Y+2.5+0.5)
+		SKY    = { cx=0, cz=390, halfX=35, halfZ=70,  baseY=81.5 },  -- FarmPlatform top=80 (SKY_BASE_Y-4.5+4.5=80)
 	}
 
 	-- Always use hardcoded baseY: bounding-box Y is skewed by tall objects (barn, trees).
@@ -136,15 +136,21 @@ local function _spawnItems(biome)
 		table.insert(usedPositions, pos)
 
 		-- Clone pre-built model from ItemModelPreloader (Blender FBX or procedural)
-		local itemModels = ServerStorage:FindFirstChild("ItemModels")
-		local prebuilt   = itemModels and itemModels:FindFirstChild(entry.name)
 		local model
-		if prebuilt then
-			model        = prebuilt:Clone()
-			model.Parent = mapModel
-		else
-			-- Fallback: build procedurally (shouldn't happen if Preloader ran)
-			model = ItemModelBuilder.build(entry.name, mapModel)
+		local buildOk, buildErr = pcall(function()
+			local itemModels = ServerStorage:FindFirstChild("ItemModels")
+			local prebuilt   = itemModels and itemModels:FindFirstChild(entry.name)
+			if prebuilt then
+				model        = prebuilt:Clone()
+				model.Parent = mapModel
+			else
+				-- Fallback: build procedurally (shouldn't happen if Preloader ran)
+				model = ItemModelBuilder.build(entry.name, mapModel)
+			end
+		end)
+		if not buildOk then
+			warn("[FarmingManager] Spawn error for '" .. entry.name .. "': " .. tostring(buildErr))
+			continue
 		end
 		local primary = model and model.PrimaryPart
 		if not primary then

--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -688,6 +688,47 @@ local function _buildFinishLine(root)
 	end
 end
 
+-- ─── Drift corner zones ───────────────────────────────────────────────────────
+-- 4 trigger volumes at S-curve apexes. Tagged "DriftCorner" so RacingManager fires
+-- DriftCharge to the player when their vehicle passes through.
+-- Amber neon strips on the track surface visually mark each zone.
+
+local function _buildDriftCorners(root)
+	local corners = {
+		{ NODES[2][1], NODES[2][2] },   -- Z= 45,  X=-22 (first left apex)
+		{ NODES[4][1], NODES[4][2] },   -- Z=-185, X=+20 (right apex)
+		{ NODES[6][1], NODES[6][2] },   -- Z=-415, X=-18 (second left apex)
+		-- midpoint of node 7→8: extra charge zone on final run-in
+		{
+			math.floor((NODES[7][1] + NODES[8][1]) / 2),
+			math.floor((NODES[7][2] + NODES[8][2]) / 2),
+		},
+	}
+	for i, c in ipairs(corners) do
+		local cx, cz = c[1], c[2]
+		-- Amber neon strip (visual)
+		_part(root, {
+			Name         = "DriftStrip_" .. i,
+			Size         = Vector3.new(TRACK_W - 2, 0.2, 38),
+			Position     = Vector3.new(cx, 1.12, cz),
+			Color        = Color3.fromRGB(255, 165, 20),
+			Material     = Enum.Material.Neon,
+			CanCollide   = false,
+			CastShadow   = false,
+			Transparency = 0.55,
+		})
+		-- Invisible trigger (tagged)
+		local trigger = _part(root, {
+			Name         = "DriftCorner_" .. i,
+			Size         = Vector3.new(TRACK_W, 5, 40),
+			Position     = Vector3.new(cx, 3.5, cz),
+			CanCollide   = false,
+			Transparency = 1,
+		})
+		_tag(trigger, "DriftCorner")
+	end
+end
+
 -- ─── Start grid ───────────────────────────────────────────────────────────────
 
 local function _buildStartGrid(root)
@@ -727,6 +768,7 @@ local function buildForest()
 	_buildJumpRamps(trackSub)
 	_buildBoostPads(trackSub)
 	_buildBarriers(trackSub)
+	_buildDriftCorners(trackSub)
 	_buildFinishLine(trackSub)
 	_buildStartGrid(trackSub)
 

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -1,9 +1,9 @@
 -- OceanMapBuilder.server.lua
 -- Procedurally builds the OCEAN biome map:
---   - Open water plane with islands
---   - Race track as floating docks / bridges
---   - Buoyancy zones, boost pads, obstacles, finish line
--- Resolves: Issue #9
+--   - Open water plane with farm island
+--   - S-curve race course marked by buoys (3 corners at Z=0, -180, -360)
+--   - Buoyancy zones, boost pads, drift corner zones, obstacles, finish line
+-- Resolves: Issue #9, #114
 
 local CollectionService = game:GetService("CollectionService")
 
@@ -11,14 +11,12 @@ local C = {
 	WATER      = Color3.fromRGB(30,  90,  180),
 	DOCK       = Color3.fromRGB(140, 100, 60),
 	SAND       = Color3.fromRGB(220, 190, 120),
-	FOAM       = Color3.fromRGB(200, 225, 255),
-	BARRIER    = Color3.fromRGB(255, 80,  40),
 	BOOST      = Color3.fromRGB(60,  200, 255),
-	ISLAND     = Color3.fromRGB(80,  140, 60),
 	PALM_TRUNK = Color3.fromRGB(120, 85,  40),
 	PALM_LEAF  = Color3.fromRGB(60,  160, 50),
 	BUOY_RED   = Color3.fromRGB(220, 50,  50),
 	BUOY_WHITE = Color3.fromRGB(240, 240, 240),
+	DRIFT_GLOW = Color3.fromRGB(40,  220, 255),
 }
 
 local MAT = {
@@ -28,22 +26,14 @@ local MAT = {
 	METAL  = Enum.Material.Metal,
 	NEON   = Enum.Material.Neon,
 	LEAVES = Enum.Material.LeafyGrass,
-	ROCK   = Enum.Material.Rock,
 }
 
-local WATER_Y = 2  -- raised 2 studs so WaterPlane top (Y=2) sits above Roblox Baseplate (Y=0)
+local WATER_Y       = 2    -- WaterPlane top face at Y=2
+local COURSE_HALF_W = 25   -- half-width of race lane (50 studs total)
+local BUOY_INTERVAL = 60   -- studs between buoy pairs
 
 local function _part(parent, props)
 	local p = Instance.new("Part")
-	p.Anchored   = true
-	p.CanCollide = true
-	for k, v in pairs(props) do pcall(function() p[k] = v end) end
-	p.Parent = parent
-	return p
-end
-
-local function _wedge(parent, props)
-	local p = Instance.new("WedgePart")
 	p.Anchored   = true
 	p.CanCollide = true
 	for k, v in pairs(props) do pcall(function() p[k] = v end) end
@@ -67,116 +57,101 @@ local function _getOrCreateMap()
 	return model
 end
 
--- ─── Water plane ────────────────────────────────────────────────────────────
+-- ─── S-curve course centerline ────────────────────────────────────────────────
+-- Three corners at Z=0, Z=-180, Z=-360 (matching neon arch markers).
+--   Z ≥  0:          straight,     center X = 0
+--   Z  0 → -180:    swing LEFT,   center X = 0  → -22
+--   Z -180 → -360:  swing RIGHT,  center X = -22 → +22
+--   Z -360 → -580:  return centre, center X = +22 →  0
+
+local function _cX(z)
+	if z >= 0 then
+		return 0
+	elseif z >= -180 then
+		return -22 * (-z / 180)
+	elseif z >= -360 then
+		local t = (-z - 180) / 180
+		return -22 + 44 * t
+	elseif z >= -580 then
+		local t = (-z - 360) / 220
+		return 22 - 22 * t
+	end
+	return 0
+end
+
+-- ─── Water plane ─────────────────────────────────────────────────────────────
 
 local function _buildWater(root)
-	-- Ocean floor (opaque, covers baseplate, gives depth colour)
 	_part(root, {
-		Name         = "OceanFloor",
-		Size         = Vector3.new(800, 2, 1800),
-		Position     = Vector3.new(0, WATER_Y - 14, 0),
-		Color        = Color3.fromRGB(8, 35, 90),
-		Material     = Enum.Material.SmoothPlastic,
-		CanCollide   = false,
-		CastShadow   = false,
+		Name = "OceanFloor", Size = Vector3.new(800, 2, 1800),
+		Position = Vector3.new(0, WATER_Y - 14, 0),
+		Color = Color3.fromRGB(8, 35, 90), Material = Enum.Material.SmoothPlastic,
+		CanCollide = false, CastShadow = false,
 	})
-	-- Mid-water volume (dark blue fill, hides anything below surface)
 	_part(root, {
-		Name         = "WaterVolume",
-		Size         = Vector3.new(700, 12, 1700),
-		Position     = Vector3.new(0, WATER_Y - 8, 0),
-		Color        = Color3.fromRGB(12, 55, 140),
-		Material     = Enum.Material.SmoothPlastic,
-		Transparency = 0.15,
-		CanCollide   = false,
-		CastShadow   = false,
+		Name = "WaterVolume", Size = Vector3.new(700, 12, 1700),
+		Position = Vector3.new(0, WATER_Y - 8, 0),
+		Color = Color3.fromRGB(12, 55, 140), Material = Enum.Material.SmoothPlastic,
+		Transparency = 0.15, CanCollide = false, CastShadow = false,
 	})
-	-- Surface plane (Glass, WATER_Y-2 centre → top face at WATER_Y, above baseplate)
 	_part(root, {
-		Name         = "WaterPlane",
-		Size         = Vector3.new(600, 4, 1600),
-		Position     = Vector3.new(0, WATER_Y - 2, 0),
-		Color        = Color3.fromRGB(25, 105, 210),
-		Material     = MAT.WATER,
-		Transparency = 0.35,
-		CanCollide   = false,
+		Name = "WaterPlane", Size = Vector3.new(600, 4, 1600),
+		Position = Vector3.new(0, WATER_Y - 2, 0),
+		Color = Color3.fromRGB(25, 105, 210), Material = MAT.WATER,
+		Transparency = 0.35, CanCollide = false,
 	})
-	-- Shimmer layer (very thin Neon strip right at the surface)
 	_part(root, {
-		Name         = "WaterShimmer",
-		Size         = Vector3.new(600, 0.25, 1600),
-		Position     = Vector3.new(0, WATER_Y, 0),
-		Color        = Color3.fromRGB(120, 200, 255),
-		Material     = Enum.Material.Neon,
-		Transparency = 0.82,
-		CanCollide   = false,
-		CastShadow   = false,
+		Name = "WaterShimmer", Size = Vector3.new(600, 0.25, 1600),
+		Position = Vector3.new(0, WATER_Y, 0),
+		Color = Color3.fromRGB(120, 200, 255), Material = Enum.Material.Neon,
+		Transparency = 0.82, CanCollide = false, CastShadow = false,
 	})
 end
 
 -- ─── Farm island (Z = 250 to 500) ────────────────────────────────────────────
 
 local function _buildFarmIsland(root)
-	-- Main island body
 	_part(root, {
-		Name     = "FarmIsland",
-		Size     = Vector3.new(160, 6, 260),
+		Name = "FarmIsland", Size = Vector3.new(160, 6, 260),
 		Position = Vector3.new(0, WATER_Y - 1, 375),
-		Color    = C.SAND,
-		Material = MAT.SAND,
+		Color = C.SAND, Material = MAT.SAND,
 	})
-	-- Grass top
 	_part(root, {
-		Name     = "FarmGrass",
-		Size     = Vector3.new(140, 1, 230),
+		Name = "FarmGrass", Size = Vector3.new(140, 1, 230),
 		Position = Vector3.new(0, WATER_Y + 2.5, 375),
-		Color    = Color3.fromRGB(80, 160, 70),
-		Material = Enum.Material.Grass,
+		Color = Color3.fromRGB(80, 160, 70), Material = Enum.Material.Grass,
 	})
 
-	-- Spawn points
 	local cols = { -50, -25, 0, 25, 50 }
 	local rows = { 290, 330 }
 	for _, row in ipairs(rows) do
 		for _, col in ipairs(cols) do
 			local sp = _part(root, {
-				Name      = "FarmSpawnPoint",
-				Size      = Vector3.new(4, 0.5, 4),
-				Position  = Vector3.new(col, WATER_Y + 3.5, row),
-				Color     = Color3.fromRGB(255, 220, 60),
-				Material  = MAT.NEON,
-				CanCollide = false,
-				Transparency = 0.5,
+				Name = "FarmSpawnPoint", Size = Vector3.new(4, 0.5, 4),
+				Position = Vector3.new(col, WATER_Y + 3.5, row),
+				Color = Color3.fromRGB(255, 220, 60), Material = MAT.NEON,
+				CanCollide = false, Transparency = 0.5,
 			})
 			_tag(sp, "FarmSpawn")
 		end
 	end
 
-	-- Palm trees on island
 	local rng = Random.new(99)
 	for _ = 1, 8 do
 		local tx = rng:NextNumber(-60, 60)
 		local tz = rng:NextNumber(260, 490)
 		local h  = rng:NextNumber(8, 14)
 		_part(root, {
-			Name     = "PalmTrunk",
-			Size     = Vector3.new(1.2, h, 1.2),
+			Name = "PalmTrunk", Size = Vector3.new(1.2, h, 1.2),
 			Position = Vector3.new(tx, WATER_Y + 2.5 + h / 2, tz),
-			Color    = C.PALM_TRUNK,
-			Material = MAT.WOOD,
-			CanCollide = false,
+			Color = C.PALM_TRUNK, Material = MAT.WOOD, CanCollide = false,
 		})
 		for i = 0, 4 do
 			local angle = (i / 5) * math.pi * 2
-			local leafX = math.cos(angle) * 4
-			local leafZ = math.sin(angle) * 4
 			_part(root, {
-				Name     = "PalmLeaf",
-				Size     = Vector3.new(0.6, 0.3, 8),
-				Position = Vector3.new(tx + leafX / 2, WATER_Y + 2.5 + h + 0.5, tz + leafZ / 2),
-				Color    = C.PALM_LEAF,
-				Material = MAT.LEAVES,
-				CFrame   = CFrame.new(tx + leafX / 2, WATER_Y + 2.5 + h + 0.5, tz + leafZ / 2)
+				Name = "PalmLeaf", Size = Vector3.new(0.6, 0.3, 8),
+				Color = C.PALM_LEAF, Material = MAT.LEAVES,
+				CFrame = CFrame.new(tx + math.cos(angle)*2, WATER_Y + 2.5 + h + 0.5, tz + math.sin(angle)*2)
 					* CFrame.Angles(0, angle, math.rad(-20)),
 				CanCollide = false,
 			})
@@ -184,210 +159,196 @@ local function _buildFarmIsland(root)
 	end
 end
 
--- ─── Open-water race course ──────────────────────────────────────────────────
--- Boats race directly on the water surface (WATER_Y = 0).
--- No solid dock platforms — course is marked by buoy lines on left and right.
--- Course width: 50 studs. Z goes from +200 (farm exit) to -600 (finish).
-
-local COURSE_HALF_W = 25   -- half-width of race lane (50 studs total)
-local BUOY_INTERVAL = 60   -- studs between buoy pairs along the course
-
--- ─── Buoyancy zone covering the full race lane ───────────────────────────────
+-- ─── Buoyancy zones ──────────────────────────────────────────────────────────
+-- Expanded X width (110) covers course shifts: ±(22 center + 25 half-width) = ±47.
 
 local function _buildBuoyancyZones(root)
-	-- One large zone covering the entire race course so boats float throughout
-	local zone = _part(root, {
-		Name         = "BuoyancyZone_Main",
-		Size         = Vector3.new(COURSE_HALF_W * 2 + 20, 6, 900),
-		Position     = Vector3.new(0, WATER_Y - 1, -200),
-		CanCollide   = false,
-		Transparency = 1,
+	local z1 = _part(root, {
+		Name = "BuoyancyZone_Main", Size = Vector3.new(110, 6, 900),
+		Position = Vector3.new(0, WATER_Y - 1, -200), CanCollide = false, Transparency = 1,
 	})
-	_tag(zone, "BuoyancyZone")
+	_tag(z1, "BuoyancyZone")
 
-	-- Additional wide zone near farm island start (boats enter from Z=200)
-	local startZone = _part(root, {
-		Name         = "BuoyancyZone_Start",
-		Size         = Vector3.new(COURSE_HALF_W * 2 + 20, 6, 200),
-		Position     = Vector3.new(0, WATER_Y - 1, 130),
-		CanCollide   = false,
-		Transparency = 1,
+	local z2 = _part(root, {
+		Name = "BuoyancyZone_Start", Size = Vector3.new(110, 6, 200),
+		Position = Vector3.new(0, WATER_Y - 1, 130), CanCollide = false, Transparency = 1,
 	})
-	_tag(startZone, "BuoyancyZone")
+	_tag(z2, "BuoyancyZone")
 end
 
--- ─── Course boundary buoys ────────────────────────────────────────────────────
+-- ─── S-curve course buoys ─────────────────────────────────────────────────────
+-- Each pair is offset by _cX(z) so boundaries follow the curve.
 
 local function _buildCourseBuoys(root)
 	local buoyIdx = 0
-
-	-- Pairs of buoys every BUOY_INTERVAL studs from Z=180 to Z=-580
 	for z = 180, -580, -BUOY_INTERVAL do
 		buoyIdx = buoyIdx + 1
-		local isRedSide = (buoyIdx % 2 == 0)  -- alternate red/white per row
+		local isRedSide = (buoyIdx % 2 == 0)
+		local cx = _cX(z)
 
 		for _, side in ipairs({ -1, 1 }) do
 			local isRed = (side == 1) == isRedSide
-			-- Buoy body (sphere-ish cylinder)
+			local bx = cx + side * COURSE_HALF_W
+
 			local body = _part(root, {
 				Name     = "Buoy_" .. buoyIdx .. (side > 0 and "R" or "L"),
 				Size     = Vector3.new(2.5, 4, 2.5),
-				Position = Vector3.new(side * COURSE_HALF_W, WATER_Y + 2, z),
+				Position = Vector3.new(bx, WATER_Y + 2, z),
 				Color    = isRed and C.BUOY_RED or C.BUOY_WHITE,
 				Material = MAT.NEON,
 			})
 			_tag(body, "Obstacle")
 
-			-- Chain/anchor pole below water
 			_part(root, {
 				Name     = "BuoyChain_" .. buoyIdx .. (side > 0 and "R" or "L"),
 				Size     = Vector3.new(0.3, 4, 0.3),
-				Position = Vector3.new(side * COURSE_HALF_W, WATER_Y - 2, z),
-				Color    = Color3.fromRGB(80, 80, 80),
-				Material = MAT.METAL,
+				Position = Vector3.new(bx, WATER_Y - 2, z),
+				Color    = Color3.fromRGB(80, 80, 80), Material = MAT.METAL,
 				CanCollide = false,
 			})
 		end
 	end
 end
 
--- ─── Corner turn markers ─────────────────────────────────────────────────────
+-- ─── Turn markers ─────────────────────────────────────────────────────────────
+-- Neon arches positioned on the course centerline at each S-curve apex.
 
 local function _buildTurnMarkers(root)
-	-- Large neon arches at key turn points to guide players
-	local turns = { 0, -180, -360, -520 }
-	for i, z in ipairs(turns) do
-		-- Left arch pillar
+	local turns = {
+		{ 0,    _cX(-90)  },   -- first swing apex (use midpoint Z=-90 for visual centering)
+		{ -180, _cX(-180) },   -- second apex: X=-22
+		{ -360, _cX(-360) },   -- third apex: X=+22
+		{ -520, _cX(-520) },   -- finish approach
+	}
+	for i, t in ipairs(turns) do
+		local tz = t[1]
+		local cx = t[2]
 		_part(root, {
-			Name     = "TurnArch_L" .. i,
-			Size     = Vector3.new(2, 12, 2),
-			Position = Vector3.new(-COURSE_HALF_W - 2, WATER_Y + 6, z),
-			Color    = Color3.fromRGB(40, 200, 255),
-			Material = MAT.NEON,
-			CanCollide = false,
+			Name = "TurnArch_L" .. i, Size = Vector3.new(2, 12, 2),
+			Position = Vector3.new(cx - COURSE_HALF_W - 2, WATER_Y + 6, tz),
+			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
 		})
-		-- Right arch pillar
 		_part(root, {
-			Name     = "TurnArch_R" .. i,
-			Size     = Vector3.new(2, 12, 2),
-			Position = Vector3.new(COURSE_HALF_W + 2, WATER_Y + 6, z),
-			Color    = Color3.fromRGB(40, 200, 255),
-			Material = MAT.NEON,
-			CanCollide = false,
+			Name = "TurnArch_R" .. i, Size = Vector3.new(2, 12, 2),
+			Position = Vector3.new(cx + COURSE_HALF_W + 2, WATER_Y + 6, tz),
+			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
 		})
-		-- Crossbar
 		_part(root, {
-			Name     = "TurnArch_Top" .. i,
-			Size     = Vector3.new(COURSE_HALF_W * 2 + 8, 2, 2),
-			Position = Vector3.new(0, WATER_Y + 12, z),
-			Color    = Color3.fromRGB(40, 200, 255),
-			Material = MAT.NEON,
-			CanCollide = false,
+			Name = "TurnArch_Top" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 8, 2, 2),
+			Position = Vector3.new(cx, WATER_Y + 12, tz),
+			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
 		})
 	end
 end
 
--- ─── Boost pads (floating platforms just above water) ────────────────────────
+-- ─── Drift corner zones ───────────────────────────────────────────────────────
+-- 3 trigger volumes at S-curve apexes; cyan wake rings mark them visually.
+
+local function _buildDriftCorners(root)
+	local corners = {
+		{ -180, _cX(-180) },   -- apex 1: X=-22 (left)
+		{ -360, _cX(-360) },   -- apex 2: X=+22 (right)
+		{ -470, _cX(-470) },   -- apex 3: X≈+9  (return leg)
+	}
+	for i, c in ipairs(corners) do
+		local cz, cx = c[1], c[2]
+
+		-- Cyan wake ring (visual)
+		_part(root, {
+			Name = "WakeRing_" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 4, 0.3, 42),
+			Position = Vector3.new(cx, WATER_Y + 0.3, cz),
+			Color = C.DRIFT_GLOW, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false, Transparency = 0.52,
+		})
+
+		-- Invisible trigger
+		local trigger = _part(root, {
+			Name = "DriftCorner_" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 22, 8, 46),
+			Position = Vector3.new(cx, WATER_Y + 1, cz),
+			CanCollide = false, Transparency = 1,
+		})
+		_tag(trigger, "DriftCorner")
+	end
+end
+
+-- ─── Boost pads (on S-curve centerline) ──────────────────────────────────────
 
 local function _buildBoostPads(root)
-	local pads = { 60, -100, -280, -450 }
-	for i, z in ipairs(pads) do
+	local padZs = { 60, -100, -280, -450 }
+	for i, z in ipairs(padZs) do
+		local cx = _cX(z)
 		local pad = _part(root, {
-			Name     = "BoostPad_" .. i,
-			Size     = Vector3.new(12, 0.4, 8),
-			Position = Vector3.new(0, WATER_Y + 0.4, z),
-			Color    = C.BOOST,
-			Material = MAT.NEON,
-			CanCollide = false,
+			Name = "BoostPad_" .. i, Size = Vector3.new(12, 0.4, 8),
+			Position = Vector3.new(cx, WATER_Y + 0.4, z),
+			Color = C.BOOST, Material = MAT.NEON, CanCollide = false,
 		})
 		_tag(pad, "BoostPad")
-		-- Visual glow ring
 		_part(root, {
-			Name     = "BoostRing_" .. i,
-			Size     = Vector3.new(16, 0.2, 12),
-			Position = Vector3.new(0, WATER_Y + 0.3, z),
-			Color    = Color3.fromRGB(100, 240, 255),
-			Material = MAT.NEON,
-			Transparency = 0.5,
-			CanCollide = false,
+			Name = "BoostRing_" .. i, Size = Vector3.new(16, 0.2, 12),
+			Position = Vector3.new(cx, WATER_Y + 0.3, z),
+			Color = Color3.fromRGB(100, 240, 255), Material = MAT.NEON,
+			Transparency = 0.5, CanCollide = false,
 		})
 	end
 end
 
--- ─── Start grid (boats start at Z=200, just below farm island) ───────────────
+-- ─── Start grid ──────────────────────────────────────────────────────────────
 
 local function _buildStartGrid(root)
-	-- Floating start platform / dock at Z=200
 	_part(root, {
-		Name     = "StartDock",
-		Size     = Vector3.new(COURSE_HALF_W * 2, 1, 20),
+		Name = "StartDock", Size = Vector3.new(COURSE_HALF_W * 2, 1, 20),
 		Position = Vector3.new(0, WATER_Y + 0.5, 200),
-		Color    = C.DOCK,
-		Material = MAT.WOOD,
+		Color = C.DOCK, Material = MAT.WOOD,
 	})
-	-- Start line banner poles
 	for side = -1, 1, 2 do
 		_part(root, {
-			Name     = "StartPole" .. (side > 0 and "R" or "L"),
-			Size     = Vector3.new(1.5, 10, 1.5),
+			Name = "StartPole" .. (side > 0 and "R" or "L"),
+			Size = Vector3.new(1.5, 10, 1.5),
 			Position = Vector3.new(side * (COURSE_HALF_W + 1), WATER_Y + 5, 192),
-			Color    = C.BUOY_WHITE,
-			Material = MAT.METAL,
+			Color = C.BUOY_WHITE, Material = MAT.METAL,
 		})
 	end
 	_part(root, {
-		Name     = "StartBanner",
-		Size     = Vector3.new(COURSE_HALF_W * 2 + 4, 2, 1),
+		Name = "StartBanner", Size = Vector3.new(COURSE_HALF_W * 2 + 4, 2, 1),
 		Position = Vector3.new(0, WATER_Y + 10, 192),
-		Color    = Color3.fromRGB(255, 220, 40),
-		Material = MAT.NEON,
-		CanCollide = false,
+		Color = Color3.fromRGB(255, 220, 40), Material = MAT.NEON, CanCollide = false,
 	})
 end
 
 -- ─── Finish line ─────────────────────────────────────────────────────────────
 
 local function _buildFinishLine(root)
-	-- Checkered floating surface at finish
 	for col = -COURSE_HALF_W, COURSE_HALF_W - 4, 4 do
 		for row = 0, 1 do
 			_part(root, {
-				Name     = "FinishTile",
-				Size     = Vector3.new(4, 0.4, 4),
+				Name = "FinishTile", Size = Vector3.new(4, 0.4, 4),
 				Position = Vector3.new(col + 2, WATER_Y + 0.4, -596 + row * 4),
-				Color    = (math.floor((col + COURSE_HALF_W) / 4) + row) % 2 == 0
+				Color = (math.floor((col + COURSE_HALF_W) / 4) + row) % 2 == 0
 					and Color3.new(1,1,1) or Color3.new(0,0,0),
-				Material = MAT.METAL,
-				CanCollide = false,
+				Material = MAT.METAL, CanCollide = false,
 			})
 		end
 	end
 
 	local finish = _part(root, {
-		Name         = "FinishLine",
-		Size         = Vector3.new(COURSE_HALF_W * 2, 8, 2),
-		Position     = Vector3.new(0, WATER_Y + 4, -598),
-		CanCollide   = false,
-		Transparency = 1,
+		Name = "FinishLine", Size = Vector3.new(COURSE_HALF_W * 2, 8, 2),
+		Position = Vector3.new(0, WATER_Y + 4, -598),
+		CanCollide = false, Transparency = 1,
 	})
 	_tag(finish, "FinishLine")
 
 	for side = -1, 1, 2 do
 		_part(root, {
-			Name     = "FinishPole" .. (side > 0 and "R" or "L"),
-			Size     = Vector3.new(1.5, 16, 1.5),
+			Name = "FinishPole" .. (side > 0 and "R" or "L"),
+			Size = Vector3.new(1.5, 16, 1.5),
 			Position = Vector3.new(side * (COURSE_HALF_W + 2), WATER_Y + 8, -598),
-			Color    = C.BUOY_WHITE,
-			Material = MAT.METAL,
+			Color = C.BUOY_WHITE, Material = MAT.METAL,
 		})
 	end
 	_part(root, {
-		Name     = "FinishArch",
-		Size     = Vector3.new(COURSE_HALF_W * 2 + 6, 2, 1.5),
+		Name = "FinishArch", Size = Vector3.new(COURSE_HALF_W * 2 + 6, 2, 1.5),
 		Position = Vector3.new(0, WATER_Y + 16, -598),
-		Color    = Color3.fromRGB(40, 160, 255),
-		Material = MAT.NEON,
-		CanCollide = false,
+		Color = Color3.fromRGB(40, 160, 255), Material = MAT.NEON, CanCollide = false,
 	})
 end
 
@@ -399,12 +360,13 @@ local function buildOcean()
 	local farmSub  = Instance.new("Model"); farmSub.Name  = "FarmArea";  farmSub.Parent  = root
 	local trackSub = Instance.new("Model"); trackSub.Name = "RaceTrack"; trackSub.Parent = root
 
-	_buildWater(root)           -- shared
-	_buildBuoyancyZones(root)   -- shared (buoyancy needed in both phases)
+	_buildWater(root)
+	_buildBuoyancyZones(root)
 	_buildFarmIsland(farmSub)
 	_buildCourseBuoys(trackSub)
 	_buildTurnMarkers(trackSub)
 	_buildBoostPads(trackSub)
+	_buildDriftCorners(trackSub)
 	_buildStartGrid(trackSub)
 	_buildFinishLine(trackSub)
 

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -239,16 +239,18 @@ end
 -- Platforms alternate color and have edge glow strips.
 -- { centerX, yOffset, centerZ, width, length }
 
+-- y offsets all 0: vehicle HoverPosition holds constant altitude (raceStartY=84),
+-- height variation was unnavigable. Horizontal X offsets kept for zigzag layout.
 local PLATFORM_DATA = {
-	{ 0,    0,   200,  42, 85  },   -- [1] transition from farm
-	{ 0,   -8,   105,  36, 65  },   -- [2] slight drop
-	{-18,  -18,   15,  36, 65  },   -- [3] drop + shift left (large gap)
-	{ 14,   5,  -90,   36, 65  },   -- [4] rise + shift right
-	{ 0,  -15, -195,  42, 85  },   -- [5] drop, wide section
-	{ 18,   8,  -310,  32, 60  },   -- [6] rise + shift right
-	{-14, -22, -415,  32, 60  },   -- [7] big drop + shift left
-	{  4,   0,  -505,  36, 80  },   -- [8] level out
-	{  0,   5,  -575,  42, 75  },   -- [9] slight rise, near finish
+	{ 0,   0,   200,  42, 85  },   -- [1] transition from farm
+	{ 0,   0,   105,  36, 65  },   -- [2]
+	{-18,  0,    15,  36, 65  },   -- [3] shift left
+	{ 14,  0,   -90,  36, 65  },   -- [4] shift right
+	{ 0,   0,  -195,  42, 85  },   -- [5] wide section
+	{ 18,  0,  -310,  32, 60  },   -- [6] shift right
+	{-14,  0,  -415,  32, 60  },   -- [7] shift left
+	{  4,  0,  -505,  36, 80  },   -- [8]
+	{  0,  0,  -575,  42, 75  },   -- [9] near finish
 }
 
 local function _buildTrackPlatforms(root)
@@ -482,6 +484,73 @@ local function _buildBoostPads(root)
 	end
 end
 
+-- ─── Drift corner rings (SKY) ─────────────────────────────────────────────────
+-- 3 crystal ring gates at the largest platform X-transitions.
+-- Tagged "DriftCorner": flying through gives boost gauge charge (no drift required).
+-- Pink-purple rings distinguish them from yellow obstacle rings.
+
+local function _buildDriftCorners(root)
+	-- 3 largest lateral transitions between platforms:
+	--   pd[3]→pd[4]: X -18→+14 (Δ32), midZ = (15 + -90)/2 = -37
+	--   pd[5]→pd[6]: X  0→+18 (Δ18), midZ = (-195 + -310)/2 = -252
+	--   pd[6]→pd[7]: X +18→-14 (Δ32), midZ = (-310 + -415)/2 = -362
+	local corners = {
+		{
+			x = (PLATFORM_DATA[3][1] + PLATFORM_DATA[4][1]) / 2,
+			y = SKY_BASE_Y + 4,
+			z = (PLATFORM_DATA[3][3] + PLATFORM_DATA[4][3]) / 2,
+		},
+		{
+			x = (PLATFORM_DATA[5][1] + PLATFORM_DATA[6][1]) / 2,
+			y = SKY_BASE_Y + 4,
+			z = (PLATFORM_DATA[5][3] + PLATFORM_DATA[6][3]) / 2,
+		},
+		{
+			x = (PLATFORM_DATA[6][1] + PLATFORM_DATA[7][1]) / 2,
+			y = SKY_BASE_Y + 4,
+			z = (PLATFORM_DATA[6][3] + PLATFORM_DATA[7][3]) / 2,
+		},
+	}
+
+	for i, c in ipairs(corners) do
+		local rx, ry, rz = c.x, c.y, c.z
+		local ringR = 14
+
+		-- 8-segment crystal ring (pink-purple to distinguish from obstacle rings)
+		for seg = 0, 7 do
+			local angle = (seg / 8) * math.pi * 2
+			local arc = _part(root, {
+				Name     = "DriftRingArc_" .. i .. "_" .. seg,
+				Size     = Vector3.new(2, 2, 8),
+				Color    = C.CRYSTAL3,
+				Material = MAT.CRYSTAL,
+				CanCollide = false, CastShadow = false,
+			})
+			arc.CFrame = CFrame.new(rx + math.cos(angle) * ringR, ry + math.sin(angle) * ringR, rz)
+				* CFrame.Angles(0, 0, angle)
+		end
+
+		-- Center star
+		_part(root, {
+			Name     = "DriftRingStar_" .. i,
+			Size     = Vector3.new(4, 4, 0.5),
+			Position = Vector3.new(rx, ry, rz),
+			Color    = C.STAR, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
+		})
+
+		-- Invisible trigger (wide box so flyer catches it even at slight Y offset)
+		local trigger = _part(root, {
+			Name         = "DriftCorner_" .. i,
+			Size         = Vector3.new(ringR * 2 + 4, ringR * 2 + 4, 50),
+			Position     = Vector3.new(rx, ry, rz),
+			CanCollide   = false,
+			Transparency = 1,
+		})
+		_tag(trigger, "DriftCorner")
+	end
+end
+
 -- ─── Kill plane ────────────────────────────────────────────────────────────────
 
 local function _buildKillPlane(root)
@@ -574,6 +643,7 @@ local function buildSky()
 	_buildCrystalClusters(trackSub)
 	_buildRingObstacles(trackSub)
 	_buildBoostPads(trackSub)
+	_buildDriftCorners(trackSub)
 	_buildKillPlane(trackSub)
 	_buildFinishLine(trackSub)
 

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -365,9 +365,35 @@ local function _setupBoostPads()
 	end
 end
 
--- ─── Drift corner reward (FOREST) ────────────────────────────────────────────
--- Drift zones tagged "DriftCorner". Client sends "driftSuccess" event;
--- server validates the player is inside a corner zone and applies slingshot.
+-- ─── Drift corner zones (all biomes) ─────────────────────────────────────────
+-- Parts tagged "DriftCorner" charge the player's boost gauge (F key) when touched.
+-- Per-zone per-player cooldown prevents farming the same corner.
+
+local function _setupDriftCorners()
+	local _cornerCooldowns = {}   -- { [partRef] = { [userId] = expireTick } }
+	for _, part in ipairs(CollectionService:GetTagged("DriftCorner")) do
+		_cornerCooldowns[part] = {}
+		part.Touched:Connect(function(hit)
+			if not _active then return end
+			local vehicle = hit:FindFirstAncestorWhichIsA("Model")
+			if not vehicle then return end
+			for _, player in ipairs(Players:GetPlayers()) do
+				local pdata = SessionManager.getData(player)
+				if pdata and pdata.vehicleModel == vehicle then
+					local cds = _cornerCooldowns[part]
+					local now = tick()
+					if cds[player.UserId] and now < cds[player.UserId] then break end
+					cds[player.UserId] = now + Constants.DRIFT_CORNER_COOLDOWN
+					RemoteEvents.DriftCharge:FireClient(player, Constants.DRIFT_CHARGE_PER_CORNER)
+					break
+				end
+			end
+		end)
+	end
+end
+
+-- ─── Manual boost activation (F key) ─────────────────────────────────────────
+-- Client invokes RequestBoost when boost gauge is full; server applies the speed burst.
 
 RemoteEvents.RequestBoost.OnServerInvoke = function(player)
 	if not _active then return "denied: not racing" end
@@ -404,7 +430,17 @@ end
 -- ─── Finish line ──────────────────────────────────────────────────────────────
 
 local function _setupFinishLine()
-	local finishPart = workspace:FindFirstChild("FinishLine", true)
+	-- Search in the active biome's map first to avoid picking up another biome's sensor.
+	local finishPart
+	if _biome then
+		local mapName   = _biome:sub(1,1):upper() .. _biome:sub(2):lower() .. "Map"
+		local mapsModel = workspace:FindFirstChild("Maps")
+		local biomeMap  = mapsModel and mapsModel:FindFirstChild(mapName)
+		finishPart = biomeMap and biomeMap:FindFirstChild("FinishLine", true)
+	end
+	if not finishPart then
+		finishPart = workspace:FindFirstChild("FinishLine", true)
+	end
 	if not finishPart then
 		warn("[RacingManager] No FinishLine Part found in Workspace")
 		return
@@ -470,6 +506,7 @@ GameManager.onPhaseChanged(function(phase, biome)
 		-- Setup collision systems
 		_setupObstacles()
 		_setupBoostPads()
+		_setupDriftCorners()   -- all biomes: charges boost gauge (F key)
 
 		if biome == "FOREST" then
 			_setupMudZones()

--- a/roblox/StarterGui/HUD/init.client.lua
+++ b/roblox/StarterGui/HUD/init.client.lua
@@ -19,6 +19,18 @@ screenGui.IgnoreGuiInset = true
 screenGui.Enabled        = false
 screenGui.Parent         = LocalPlayer.PlayerGui
 
+-- ── Drift / Boost key hint ──────────────────────────────────────────────────
+local keyHint = Instance.new("TextLabel")
+keyHint.Name             = "KeyHint"
+keyHint.Size             = UDim2.new(0, 240, 0, 14)
+keyHint.Position         = UDim2.new(0.5, -120, 1, -38)
+keyHint.BackgroundTransparency = 1
+keyHint.Text             = "[ SHIFT = Drift  ·  F = Boost ]"
+keyHint.TextColor3       = Color3.fromRGB(160, 160, 160)
+keyHint.TextScaled       = true
+keyHint.Font             = Enum.Font.Gotham
+keyHint.Parent           = screenGui
+
 -- ── Boost Bar ──────────────────────────────────────────────────────────────
 local boostBar = Instance.new("Frame")
 boostBar.Name            = "BoostBar"

--- a/roblox/StarterPlayer/StarterPlayerScripts/Modules/CameraController.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/Modules/CameraController.lua
@@ -79,8 +79,14 @@ local function _racingLoop(vehicle)
 		if not vehicle or not vehicle.PrimaryPart then return end
 
 		local primary = vehicle.PrimaryPart
-		local lookDir = primary.CFrame.LookVector
-		local vel     = primary.AssemblyLinearVelocity.Magnitude
+
+		-- SKY flyer fuselage is a Cylinder rotated Ry(π/2):
+		--   its length (local X) → world -Z (forward), but LookVector → world -X (left).
+		--   Use RightVector instead, which equals world -Z for the flyer.
+		local biomeTag = vehicle:FindFirstChild("BiomeTag")
+		local isSky    = biomeTag and biomeTag.Value == "SKY"
+		local lookDir  = isSky and primary.CFrame.RightVector or primary.CFrame.LookVector
+		local vel      = primary.AssemblyLinearVelocity.Magnitude
 
 		-- Dynamic FOV: 70 at rest, up to 90 at max speed
 		local targetFOV = _baseFOV + math.min(vel * 0.12, 20)

--- a/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
@@ -1,6 +1,8 @@
 -- RacingClient.client.lua
 -- Vehicle controls, drift, boost, screen effects, and ability input.
--- Resolves: Issue #30, #31, #66
+-- Key bindings: WASD/arrows = drive; Shift = drift slide; F = activate boost;
+--   E = ability; R = respawn; Space/Ctrl = altitude (SKY only).
+-- Resolves: Issue #30, #31, #66, #114
 
 local Players          = game:GetService("Players")
 local UserInputService = game:GetService("UserInputService")
@@ -25,7 +27,7 @@ local _stats         = nil   -- vehicleStats table
 local _biome         = nil
 local _drifting      = false
 local _boostActive   = false
-local _boostGauge    = 1.0   -- 0–1, refills over BOOST_COOLDOWN
+local _boostGauge    = 1.0   -- 0–1, charges via DriftCorner zones
 local _heartbeatConn = nil
 local _baseFOV       = 70
 local _abilitySlots  = {}    -- { slotName → itemName } from crafting
@@ -36,48 +38,47 @@ local _keys = {
 	W = false, A = false, S = false, D = false,
 	Up = false, Down = false, Left = false, Right = false,
 	Shift = false, Space = false, Ctrl = false,
-	E = false,   -- ability key
+	E = false,   -- ability
+	F = false,   -- boost activation
 }
 
--- Reusable raycast params for suspension (filter updated when vehicle spawns)
 local _suspParams = RaycastParams.new()
 _suspParams.FilterType = Enum.RaycastFilterType.Exclude
 
 local KEY_MAP = {
-	[Enum.KeyCode.W]     = "W",
-	[Enum.KeyCode.A]     = "A",
-	[Enum.KeyCode.S]     = "S",
-	[Enum.KeyCode.D]     = "D",
-	[Enum.KeyCode.Up]    = "Up",
-	[Enum.KeyCode.Down]  = "Down",
-	[Enum.KeyCode.Left]  = "Left",
-	[Enum.KeyCode.Right] = "Right",
+	[Enum.KeyCode.W]           = "W",
+	[Enum.KeyCode.A]           = "A",
+	[Enum.KeyCode.S]           = "S",
+	[Enum.KeyCode.D]           = "D",
+	[Enum.KeyCode.Up]          = "Up",
+	[Enum.KeyCode.Down]        = "Down",
+	[Enum.KeyCode.Left]        = "Left",
+	[Enum.KeyCode.Right]       = "Right",
 	[Enum.KeyCode.LeftShift]   = "Shift",
 	[Enum.KeyCode.RightShift]  = "Shift",
 	[Enum.KeyCode.Space]       = "Space",
 	[Enum.KeyCode.LeftControl] = "Ctrl",
 	[Enum.KeyCode.RightControl]= "Ctrl",
-	[Enum.KeyCode.E]     = "E",
+	[Enum.KeyCode.E]           = "E",
+	[Enum.KeyCode.F]           = "F",
 }
 
 UserInputService.InputBegan:Connect(function(input, processed)
 	local k = KEY_MAP[input.KeyCode]
-	if k then _keys[k] = true end  -- always track, even when VehicleSeat marks input as processed
+	if k then _keys[k] = true end
 
 	if processed then return end
 	if not _active then return end
 
-	-- Boost
-	if k == "Shift" and not _boostActive and _boostGauge >= 1 then
+	-- F key: activate boost when gauge is full
+	if k == "F" and not _boostActive and _boostGauge >= 1 then
 		_triggerBoost()
 	end
 
-	-- Ability
 	if k == "E" then
 		_triggerAbility()
 	end
 
-	-- Manual respawn (R key) — useful when stuck off-track
 	if input.KeyCode == Enum.KeyCode.R then
 		RemoteEvents.RequestRespawn:InvokeServer()
 	end
@@ -89,13 +90,49 @@ UserInputService.InputEnded:Connect(function(input)
 
 	if not _active then return end
 
-	-- End drift when Shift released
 	if k == "Shift" and _drifting then
 		_exitDrift()
 	end
 end)
 
+-- ─── Screen overlay helpers ───────────────────────────────────────────────────
+
+local function _getOverlay()
+	local existing = LocalPlayer.PlayerGui:FindFirstChild("RaceOverlay")
+	if existing then return existing end
+
+	local gui = Instance.new("ScreenGui")
+	gui.Name           = "RaceOverlay"
+	gui.ResetOnSpawn   = false
+	gui.IgnoreGuiInset = true
+	gui.Parent         = LocalPlayer.PlayerGui
+
+	local tint = Instance.new("Frame")
+	tint.Name = "Tint"
+	tint.Size = UDim2.fromScale(1, 1)
+	tint.BackgroundColor3 = Color3.new(1, 1, 1)
+	tint.BackgroundTransparency = 1
+	tint.Parent = gui
+	return gui
+end
+
+function _applyScreenTint(colour, alpha, duration)
+	local gui  = _getOverlay()
+	local tint = gui:FindFirstChild("Tint")
+	if not tint then return end
+	tint.BackgroundColor3 = colour
+	TweenService:Create(tint, TweenInfo.new(0.1), {
+		BackgroundTransparency = 1 - alpha
+	}):Play()
+	task.delay(duration, function()
+		TweenService:Create(tint, TweenInfo.new(0.3), {
+			BackgroundTransparency = 1
+		}):Play()
+	end)
+end
+
 -- ─── Boost ────────────────────────────────────────────────────────────────────
+-- F key activates boost. Gauge charges from DriftCorner zones.
 
 function _triggerBoost()
 	local result = RemoteEvents.RequestBoost:InvokeServer()
@@ -103,50 +140,130 @@ function _triggerBoost()
 
 	_boostActive = true
 	_boostGauge  = 0
+	_updateBoostHUD()
 
-	-- FOV punch
-	TweenService:Create(Camera, TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
-		FieldOfView = _baseFOV + 20
+	local boostColor
+	if _biome == "OCEAN" then
+		boostColor = Color3.fromRGB(60, 200, 255)
+	elseif _biome == "SKY" then
+		boostColor = Color3.fromRGB(180, 100, 255)
+	else
+		boostColor = Color3.fromRGB(100, 200, 255)
+	end
+	_applyScreenTint(boostColor, 0.4, 0.25)
+
+	TweenService:Create(Camera, TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.Out), {
+		FieldOfView = _baseFOV + 22
 	}):Play()
 
-	-- Screen effect
-	RemoteEvents.ScreenEffect:FireServer("boostStart", {})   -- not real; just local
-	_applyScreenTint(Color3.fromRGB(100, 200, 255), 0.35, 0.2)
-
-	local stats = _stats
-	local dur   = (stats and stats.boostDuration) or Constants.BOOST_DURATION
-
+	local dur = (_stats and _stats.boostDuration) or Constants.BOOST_DURATION
 	task.delay(dur, function()
 		_boostActive = false
 		TweenService:Create(Camera, TweenInfo.new(0.5, Enum.EasingStyle.Quad), {
 			FieldOfView = _baseFOV
 		}):Play()
-		-- Cooldown refill
-		task.spawn(_refillBoost)
 	end)
 end
 
-function _refillBoost()
-	local step = 1 / Constants.BOOST_COOLDOWN
-	while _boostGauge < 1 do
-		task.wait(0.05)
-		_boostGauge = math.min(1, _boostGauge + step * 0.05)
-		_updateBoostHUD()
+-- ─── Boost HUD ────────────────────────────────────────────────────────────────
+
+local _boostBar   = nil
+local _boostLabel = nil
+
+local function _ensureBoostHUD()
+	if _boostBar then return end
+	local hud = LocalPlayer.PlayerGui:FindFirstChild("HUD")
+	if not hud then return end
+	local frame = hud:FindFirstChild("BoostBar")
+	if not frame then return end
+	_boostBar   = frame:FindFirstChild("Fill")
+	_boostLabel = frame:FindFirstChild("Label")
+end
+
+function _updateBoostHUD()
+	if not _boostBar then _ensureBoostHUD() end
+	if not _boostBar then return end
+	TweenService:Create(_boostBar, TweenInfo.new(0.15), {
+		Size = UDim2.new(_boostGauge, 0, 1, 0)
+	}):Play()
+	if _boostLabel then
+		_boostLabel.Text = _boostGauge >= 1 and "BOOST  [F]" or "BOOST"
 	end
 end
 
+function _showBoostReady()
+	if not _boostBar then _ensureBoostHUD() end
+	if not _boostBar then return end
+	local frame = _boostBar.Parent
+	TweenService:Create(frame, TweenInfo.new(0.18, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {
+		Size = UDim2.new(0, 220, 0, 22)
+	}):Play()
+	task.delay(0.25, function()
+		TweenService:Create(frame, TweenInfo.new(0.18), {
+			Size = UDim2.new(0, 200, 0, 18)
+		}):Play()
+	end)
+	_applyScreenTint(Color3.fromRGB(255, 220, 50), 0.12, 0.2)
+end
+
 -- ─── Drift ────────────────────────────────────────────────────────────────────
+-- Shift + steer + >50% speed → enter drift (TurnSpeed reduced, slides wide).
+-- DriftCorner zone touch (server) → DriftCharge event → fills gauge.
+-- F key with full gauge → activate boost slingshot.
 
 local _driftGripBackup = nil
+local _driftLabel      = nil
+
+local function _ensureDriftLabel()
+	if _driftLabel and _driftLabel.Parent then return _driftLabel end
+	local overlay = _getOverlay()
+	local lbl = Instance.new("TextLabel")
+	lbl.Name             = "DriftIndicator"
+	lbl.Size             = UDim2.new(0, 160, 0, 40)
+	lbl.AnchorPoint      = Vector2.new(0.5, 1)
+	lbl.Position         = UDim2.new(0.5, 0, 1, -112)
+	lbl.BackgroundTransparency = 1
+	lbl.TextScaled       = true
+	lbl.Font             = Enum.Font.GothamBold
+	lbl.TextStrokeTransparency = 0.4
+	lbl.TextTransparency = 1
+	lbl.Parent           = overlay
+	_driftLabel = lbl
+	return lbl
+end
+
+local function _showDriftLabel(text, color)
+	local lbl = _ensureDriftLabel()
+	lbl.Text       = text
+	lbl.TextColor3 = color
+	TweenService:Create(lbl, TweenInfo.new(0.15, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {
+		TextTransparency = 0,
+	}):Play()
+end
+
+local function _hideDriftLabel()
+	if not _driftLabel then return end
+	TweenService:Create(_driftLabel, TweenInfo.new(0.3), {
+		TextTransparency = 1,
+	}):Play()
+end
 
 local function _enterDrift()
 	if not _seat or _drifting then return end
-	_drifting       = true
+	_drifting        = true
 	_driftGripBackup = _seat.TurnSpeed
-	-- Reduce TurnSpeed cap → vehicle slides wide
 	_seat.TurnSpeed  = math.max(_seat.TurnSpeed * 0.35, 0.3)
-	_applyScreenTint(Color3.fromRGB(220, 160, 40), 0.2, 0.1)
-	RemoteEvents.ScreenEffect:FireServer("driftStart", {})
+
+	local driftColor, driftText
+	if _biome == "OCEAN" then
+		driftColor = Color3.fromRGB(40, 170, 255)
+		driftText  = "WAKE"
+	else
+		driftColor = Color3.fromRGB(230, 160, 35)
+		driftText  = "DRIFT"
+	end
+	_applyScreenTint(driftColor, 0.22, 0.12)
+	_showDriftLabel(driftText, driftColor)
 end
 
 function _exitDrift()
@@ -156,19 +273,58 @@ function _exitDrift()
 		_seat.TurnSpeed = _driftGripBackup
 		_driftGripBackup = nil
 	end
-	-- Slingshot: brief speed bonus
-	if _seat then
-		local old = _seat.MaxSpeed
-		_seat.MaxSpeed = old * 1.15
-		task.delay(1.5, function()
-			if _seat and _seat.Parent then _seat.MaxSpeed = old end
-		end)
-	end
+	_hideDriftLabel()
+	-- No local slingshot: DriftCorner zones charge the boost gauge instead.
 end
 
+-- ─── DriftCharge listener ─────────────────────────────────────────────────────
+
+local function _showCornerCharge()
+	local overlay = _getOverlay()
+	local lbl = overlay:FindFirstChild("CornerFlash")
+	if not lbl then
+		lbl = Instance.new("TextLabel")
+		lbl.Name             = "CornerFlash"
+		lbl.Size             = UDim2.new(0, 180, 0, 28)
+		lbl.AnchorPoint      = Vector2.new(0.5, 1)
+		lbl.Position         = UDim2.new(0.5, 0, 1, -158)
+		lbl.BackgroundTransparency = 1
+		lbl.TextScaled       = true
+		lbl.Font             = Enum.Font.GothamBold
+		lbl.TextStrokeTransparency = 0.4
+		lbl.Parent           = overlay
+	end
+
+	local text, color
+	if _biome == "OCEAN" then
+		text  = "WAKE BONUS +"
+		color = Color3.fromRGB(60, 220, 255)
+	elseif _biome == "SKY" then
+		text  = "RING BONUS +"
+		color = Color3.fromRGB(200, 140, 255)
+	else
+		text  = "CORNER +"
+		color = Color3.fromRGB(255, 220, 50)
+	end
+	lbl.Text       = text
+	lbl.TextColor3 = color
+	lbl.TextTransparency = 0
+	TweenService:Create(lbl, TweenInfo.new(1.2, Enum.EasingStyle.Quad), {
+		TextTransparency = 1,
+	}):Play()
+	_applyScreenTint(color, 0.15, 0.15)
+end
+
+RemoteEvents.DriftCharge.OnClientEvent:Connect(function(amount)
+	_boostGauge = math.min(1, _boostGauge + (amount or Constants.DRIFT_CHARGE_PER_CORNER))
+	_updateBoostHUD()
+	_showCornerCharge()
+	if _boostGauge >= 1 then
+		_showBoostReady()
+	end
+end)
+
 -- ─── Vehicle drive loop ───────────────────────────────────────────────────────
--- FOREST/OCEAN: VehicleSeat built-in handles throttle/steer. Loop detects drift.
--- SKY: No ground contact → manually drive via BodyVelocity each frame.
 
 local function _driveLoop()
 	if not _vehicle or not _vehicle.PrimaryPart then return end
@@ -183,7 +339,6 @@ local function _driveLoop()
 	local throttle, steer
 
 	if _biome == "SKY" then
-		-- SKY: VehicleSeat has no ground contact — read _keys directly.
 		throttle = 0
 		if _keys.W or _keys.Up   then throttle =  1 end
 		if _keys.S or _keys.Down then throttle = -0.5 end
@@ -192,7 +347,6 @@ local function _driveLoop()
 		if _keys.D or _keys.Right then steer = -1 end
 		turnSpeed = math.min(turnSpeed, 1.5)
 
-		-- Altitude: Space = 상승, Ctrl = 하강
 		local hover = primary:FindFirstChild("HoverPosition")
 		if hover then
 			local dt = 1 / 60
@@ -203,27 +357,20 @@ local function _driveLoop()
 			end
 		end
 	else
-		-- FOREST/OCEAN: read _keys directly (same as SKY) — avoids VehicleSeat
-		-- network ownership delays that cause ThrottleFloat/SteerFloat to stick at 0.
 		if not _seat then return end
 		throttle = 0
 		if _keys.W or _keys.Up   then throttle =  1 end
 		if _keys.S or _keys.Down then throttle = -0.5 end
 		steer = 0
-		if _keys.A or _keys.Left  then steer =  1 end   -- +Y = left turn
-		if _keys.D or _keys.Right then steer = -1 end   -- -Y = right turn
+		if _keys.A or _keys.Left  then steer =  1 end
+		if _keys.D or _keys.Right then steer = -1 end
 
-		-- Drift entry (steering key instead of SteerFloat)
 		local isSteering = _keys.A or _keys.D or _keys.Left or _keys.Right
 		if _keys.Shift and isSteering and not _drifting then
 			local vel = primary.AssemblyLinearVelocity.Magnitude
 			if vel > maxSpeed * 0.5 then _enterDrift() end
 		end
 
-		-- Suspension raycast (FOREST only — OCEAN uses server-side buoyancy BodyForce).
-		-- Casts a ray downward each frame; moves SuspensionHover target to keep the
-		-- vehicle center at half-height + 0.2 above whatever surface is below it.
-		-- This lets the vehicle ride over curbs and bumps instead of stopping against them.
 		if _biome == "FOREST" then
 			local susp = primary:FindFirstChild("SuspensionHover")
 			if susp then
@@ -241,17 +388,16 @@ local function _driveLoop()
 					)
 					susp.MaxForce = Vector3.new(0, 4e4, 0)
 				else
-					susp.MaxForce = Vector3.zero  -- airborne: let gravity handle Y
+					susp.MaxForce = Vector3.zero
 				end
 			end
 		end
 	end
 
 	local forward = primary.CFrame.LookVector
-	bv.Velocity            = forward * throttle * maxSpeed
-	bav.AngularVelocity    = Vector3.new(0, steer * turnSpeed, 0)
+	bv.Velocity         = forward * throttle * maxSpeed
+	bav.AngularVelocity = Vector3.new(0, steer * turnSpeed, 0)
 
-	-- Keep UprightGyro tracking current Y so it only resists X/Z tilt.
 	local gyro = primary:FindFirstChild("UprightGyro")
 	if gyro then
 		local _, currentY, _ = primary.CFrame:ToEulerAnglesYXZ()
@@ -261,15 +407,13 @@ end
 
 -- ─── Ability activation ───────────────────────────────────────────────────────
 
--- Cycle through SPECIAL → ENGINE → BODY slots on each E press
-local _abilityOrder  = { "SPECIAL", "ENGINE", "BODY" }
-local _abilityIndex  = 1
+local _abilityOrder = { "SPECIAL", "ENGINE", "BODY" }
+local _abilityIndex = 1
 
 function _triggerAbility()
 	local slotName = _abilityOrder[_abilityIndex]
 	local itemName = _abilitySlots[slotName]
 	if not itemName then
-		-- Try next slot
 		_abilityIndex = (_abilityIndex % #_abilityOrder) + 1
 		slotName  = _abilityOrder[_abilityIndex]
 		itemName  = _abilitySlots[slotName]
@@ -282,60 +426,20 @@ function _triggerAbility()
 	end
 end
 
--- ─── Screen effects ───────────────────────────────────────────────────────────
-
-local _overlayGui = nil
-
-local function _getOverlay()
-	if _overlayGui then return _overlayGui end
-	_overlayGui = Instance.new("ScreenGui")
-	_overlayGui.Name           = "RaceOverlay"
-	_overlayGui.ResetOnSpawn   = false
-	_overlayGui.IgnoreGuiInset = true
-	_overlayGui.Parent         = LocalPlayer.PlayerGui
-
-	local frame = Instance.new("Frame")
-	frame.Name = "Tint"
-	frame.Size = UDim2.fromScale(1, 1)
-	frame.BackgroundColor3 = Color3.new(1, 1, 1)
-	frame.BackgroundTransparency = 1
-	frame.Parent = _overlayGui
-	return _overlayGui
-end
-
-function _applyScreenTint(colour, alpha, duration)
-	local gui   = _getOverlay()
-	local tint  = gui:FindFirstChild("Tint")
-	if not tint then return end
-	tint.BackgroundColor3 = colour
-	TweenService:Create(tint, TweenInfo.new(0.1), {
-		BackgroundTransparency = 1 - alpha
-	}):Play()
-	task.delay(duration, function()
-		TweenService:Create(tint, TweenInfo.new(0.3), {
-			BackgroundTransparency = 1
-		}):Play()
-	end)
-end
-
-local function _cameraShake(intensity, duration)
-	local steps = math.floor(duration / 0.05)
-	task.spawn(function()
-		for _ = 1, steps do
-			local rx = (math.random() - 0.5) * intensity
-			local ry = (math.random() - 0.5) * intensity
-			Camera.CFrame = Camera.CFrame * CFrame.Angles(rx, ry, 0)
-			task.wait(0.05)
-		end
-	end)
-end
-
 -- ─── ScreenEffect listener ───────────────────────────────────────────────────
 
 RemoteEvents.ScreenEffect.OnClientEvent:Connect(function(effectName, params)
 	if effectName == "collision" then
 		_applyScreenTint(Color3.fromRGB(255, 100, 50), 0.4, 0.3)
-		_cameraShake(0.04, 0.4)
+		local steps = math.floor(0.4 / 0.05)
+		task.spawn(function()
+			for _ = 1, steps do
+				Camera.CFrame = Camera.CFrame * CFrame.Angles(
+					(math.random() - 0.5) * 0.04,
+					(math.random() - 0.5) * 0.04, 0)
+				task.wait(0.05)
+			end
+		end)
 
 	elseif effectName == "mudWarning" then
 		_applyScreenTint(Color3.fromRGB(100, 70, 30), 0.25, 0.5)
@@ -355,33 +459,20 @@ RemoteEvents.ScreenEffect.OnClientEvent:Connect(function(effectName, params)
 
 	elseif effectName == "bubblePop" then
 		_applyScreenTint(Color3.fromRGB(150, 220, 255), 0.5, 0.3)
-		_cameraShake(0.03, 0.2)
+		local steps = math.floor(0.2 / 0.05)
+		task.spawn(function()
+			for _ = 1, steps do
+				Camera.CFrame = Camera.CFrame * CFrame.Angles(
+					(math.random() - 0.5) * 0.03,
+					(math.random() - 0.5) * 0.03, 0)
+				task.wait(0.05)
+			end
+		end)
 
 	elseif effectName == "hackControls" then
-		-- Visual feedback that you're being hacked
 		_applyScreenTint(Color3.fromRGB(50, 200, 50), 0.4, (params and params.duration) or 5)
 	end
 end)
-
--- ─── Boost HUD ───────────────────────────────────────────────────────────────
-
-local _boostBar = nil
-
-local function _ensureBoostHUD()
-	if _boostBar then return end
-	local hud = LocalPlayer.PlayerGui:FindFirstChild("HUD")
-	if not hud then return end
-	local frame = hud:FindFirstChild("BoostBar")
-	if frame then _boostBar = frame:FindFirstChild("Fill") end
-end
-
-function _updateBoostHUD()
-	if not _boostBar then _ensureBoostHUD() end
-	if not _boostBar then return end
-	TweenService:Create(_boostBar, TweenInfo.new(0.1), {
-		Size = UDim2.new(_boostGauge, 0, 1, 0)
-	}):Play()
-end
 
 -- ─── Camera follow ────────────────────────────────────────────────────────────
 
@@ -389,10 +480,23 @@ local function _updateCamera()
 	if not _vehicle or not _vehicle.PrimaryPart then return end
 	local primary = _vehicle.PrimaryPart
 	local lookDir = primary.CFrame.LookVector
-	local offset  = Vector3.new(0, 5, 12)
-	local camPos  = primary.Position - lookDir * offset.Z + Vector3.new(0, offset.Y, 0)
-	local camCF   = CFrame.new(camPos, primary.Position + Vector3.new(0, 1.5, 0))
-	Camera.CFrame = Camera.CFrame:Lerp(camCF, 0.12)
+	local camPos  = primary.Position - lookDir * 12 + Vector3.new(0, 5, 0)
+	Camera.CFrame = Camera.CFrame:Lerp(CFrame.new(camPos, primary.Position + Vector3.new(0, 1.5, 0)), 0.12)
+end
+
+-- ─── Speedometer update ───────────────────────────────────────────────────────
+
+local _speedLabel = nil
+
+local function _updateSpeedHUD()
+	if not _speedLabel then
+		local hud = LocalPlayer.PlayerGui:FindFirstChild("HUD")
+		local sf  = hud and hud:FindFirstChild("Speedometer")
+		_speedLabel = sf and sf:FindFirstChild("Value")
+	end
+	if not _speedLabel or not _vehicle or not _vehicle.PrimaryPart then return end
+	local vel = _vehicle.PrimaryPart.AssemblyLinearVelocity.Magnitude
+	_speedLabel.Text = tostring(math.floor(vel * 0.28 * 3.6))
 end
 
 -- ─── VehicleSpawned listener ─────────────────────────────────────────────────
@@ -401,19 +505,14 @@ RemoteEvents.VehicleSpawned.OnClientEvent:Connect(function(userId, vehicleModel)
 	if userId ~= LocalPlayer.UserId then return end
 	_vehicle = vehicleModel
 	_seat    = vehicleModel:FindFirstChildWhichIsA("VehicleSeat", true)
-	_suspParams.FilterDescendantsInstances = {vehicleModel}  -- exclude vehicle from suspension raycast
+	_suspParams.FilterDescendantsInstances = {vehicleModel}
 
-	-- VehicleSeat may not have replicated yet — retry for up to 3 seconds
 	if not _seat then
 		task.spawn(function()
 			local deadline = tick() + 3
-			repeat
-				task.wait(0.05)
-				_seat = vehicleModel:FindFirstChildWhichIsA("VehicleSeat", true)
+			repeat task.wait(0.05); _seat = vehicleModel:FindFirstChildWhichIsA("VehicleSeat", true)
 			until _seat or tick() > deadline
-			if not _seat then
-				warn("[RacingClient] VehicleSeat never found on vehicle model")
-			end
+			if not _seat then warn("[RacingClient] VehicleSeat never found") end
 		end)
 	end
 
@@ -424,18 +523,16 @@ end)
 -- ─── Enable / Disable ─────────────────────────────────────────────────────────
 
 function RacingClient.enable()
-	_active      = true
-	_boostActive = false
-	_boostGauge  = 1
-	_drifting    = false
+	_active       = true
+	_boostActive  = false
+	_boostGauge   = 1
+	_drifting     = false
 	_abilityIndex = 1
+	_updateBoostHUD()
 
-	-- Prevent Space from triggering a jump and ejecting the player from the seat.
 	local hum = LocalPlayer.Character and LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
 	if hum then hum.JumpHeight = 0 end
 
-	-- Get slot assignments from CraftingClient state (via a shared binding or
-	-- stored value in PlayerGui tag — set when SubmitCraft fires)
 	local tag = LocalPlayer.PlayerGui:FindFirstChild("CraftSlots")
 	if tag then
 		for _, v in ipairs(tag:GetChildren()) do
@@ -450,32 +547,28 @@ function RacingClient.enable()
 		if not _active then return end
 		_driveLoop()
 		_updateCamera()
+		_updateSpeedHUD()
 	end)
 end
 
 function RacingClient.disable()
 	_active = false
-	if _heartbeatConn then
-		_heartbeatConn:Disconnect()
-		_heartbeatConn = nil
-	end
+	if _heartbeatConn then _heartbeatConn:Disconnect(); _heartbeatConn = nil end
 	Camera.CameraType  = Enum.CameraType.Custom
 	Camera.FieldOfView = _baseFOV
 	_vehicle = nil
 	_seat    = nil
+	_hideDriftLabel()
 
-	-- Restore jumping after race ends.
 	local hum = LocalPlayer.Character and LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
 	if hum then hum.JumpHeight = 7.2 end
 end
 
--- ─── Biome listener ──────────────────────────────────────────────────────────
+-- ─── Biome / Phase listeners ─────────────────────────────────────────────────
 
 RemoteEvents.BiomeSelected.OnClientEvent:Connect(function(biome)
 	_biome = biome
 end)
-
--- ─── Self-manage via PhaseChanged ────────────────────────────────────────────
 
 RemoteEvents.PhaseChanged.OnClientEvent:Connect(function(phase)
 	if phase == Constants.PHASES.RACING then


### PR DESCRIPTION
Closes #114

## Summary

- **FOREST**: S커브 4개 코너에 amber DriftCorner 존 추가 (nodes 2/4/6 + 마지막 구간)
- **OCEAN**: 직선 코스 → S커브 코스 재설계. 부표가 `_cX(z)` 센터라인을 따라 배치됨. 3개 cyan wake-ring DriftCorner 존 (Z=−180/−360/−470 apex)
- **SKY**: 가장 큰 플랫폼 X-전환 구간(pd3→4, pd5→6, pd6→7)에 pink-purple 크리스탈 링 DriftCorner 게이트 3개
- **Boost 키 분리**: Shift = 드리프트 전용, F = 부스트 활성화 (게이지 풀일 때)
- **DriftCharge 이벤트**: DriftCorner 터치 시 서버 → 클라이언트 게이지 +0.5 (2코너 = 풀게이지)
- **드리프트 UI**: "DRIFT" / "WAKE" 바이옴별 레이블, "CORNER +" 플래시, 부스트 바 "[F]" 힌트

## Biome cornering

| 바이옴 | 코너링 | 드리프트 |
|--------|--------|---------|
| FOREST | ✅ S커브 (노드 2/4/6) | ✅ Shift+조향 슬라이드 |
| OCEAN | ✅ 새 S커브 3코너 | ✅ Shift+조향 wake슬라이드 |
| SKY | ✅ 플랫폼 X전환 3구간 | N/A (DriveVelocity 직접 제어) → 링 통과 시 게이지 충전 |

## Test plan

- [ ] FOREST: 드리프트 중 코너 존 진입 시 amber 스트립 보이고 "CORNER +" 플래시 + 게이지 상승
- [ ] OCEAN: 부표가 S커브를 따라 배치되었는지 확인; 코너 진입 시 "WAKE BONUS +" 표시
- [ ] SKY: 크리스탈 링 통과 시 "RING BONUS +" 표시 + 게이지 상승
- [ ] F키로 부스트 활성화 (게이지 풀일 때)
- [ ] Shift = 드리프트만 (부스트 없음)
- [ ] 부스트 바: "BOOST [F]" 텍스트 + 풀 충전 시 pulse 애니메이션

🤖 Generated with [Claude Code](https://claude.ai/claude-code)