### PR TITLE
fix(#118): remove rarity SelectionBox bounding box

### DIFF
--- a/roblox/ServerScriptService/Modules/ItemVisualUpgrader.lua
+++ b/roblox/ServerScriptService/Modules/ItemVisualUpgrader.lua
@@ -186,18 +186,6 @@ local function _addEpicOrbs(model, primary)
 	end
 end
 
--- ─── Neon edge highlight ─────────────────────────────────────────────────────
-
-local function _addNeonEdge(model, primary, colour)
-	-- Thin neon outline slightly larger than primary
-	local edge = Instance.new("SelectionBox")
-	edge.Adornee    = primary
-	edge.Color3     = colour
-	edge.LineThickness = 0.04
-	edge.SurfaceTransparency = 1
-	edge.Parent     = model
-end
-
 -- ─── Reflectance upgrade ─────────────────────────────────────────────────────
 
 local function _upgradeReflectance(model, reflectance)
@@ -274,7 +262,6 @@ function ItemVisualUpgrader.apply(model, rarity)
 	-- 2. Glow ring (Uncommon+)
 	if cfg.glowParts and cfg.glowColour then
 		_addGlowRing(model, primary, cfg.glowColour)
-		_addNeonEdge(model, primary, cfg.glowColour)
 	end
 
 	-- 3. Particle aura (Rare+)


### PR DESCRIPTION
## Summary
- `ItemVisualUpgrader._addNeonEdge`가 생성하는 `SelectionBox`가 아이템 위에 bounding box outline을 그려 아이템이 잘 안 보이는 문제 수정
- 함수 및 호출부 완전 제거
- GlowRing + ParticleEmitter만으로 희귀도 표현 유지

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)