### PR TITLE
refactor(#127): per-biome track dimensions in Constants

### DIFF
--- a/roblox/ReplicatedStorage/Shared/Constants.lua
+++ b/roblox/ReplicatedStorage/Shared/Constants.lua
@@ -56,9 +56,22 @@ Constants.MOBILITY_SLOT_NAMES = {
 Constants.MOBILITY_EMPTY_PENALTY = 0.30  -- 30% reduction to biome core stat
 
 -- ─── Vehicle / Track ──────────────────────────────────────────────────────────
-Constants.TRACK_LENGTH     = 1200
-Constants.TRACK_WIDTH      = 40
-Constants.FINISH_Z         = -1000
+-- Per-biome track dimensions. Races run along -Z from zStart to zFinish.
+-- Lengths derived from the per-biome racetrack spec (90s playtime × avg speed):
+--   FOREST 4700-stud path / 2600-stud Z-extent (figure-3 + U-bend, path/Z ~1.8)
+--   OCEAN  3400-stud path / 2100-stud Z-extent (arc-S + U-bend,    path/Z ~1.6)
+--   SKY    7800-stud path / 3500-stud Z-extent (planar figure-8,   path/Z ~2.2)
+Constants.TRACK = {
+	FOREST = { zStart = 600,  zFinish = -2000, width = 40 },
+	OCEAN  = { zStart = 600,  zFinish = -1500, width = 60 },
+	SKY    = { zStart = 1500, zFinish = -2000, width = 50 },
+}
+
+function Constants.getTrackLength(biome)
+	local t = Constants.TRACK[biome]
+	assert(t, "Constants.getTrackLength: unknown biome " .. tostring(biome))
+	return t.zStart - t.zFinish
+end
 
 -- ─── Racing ───────────────────────────────────────────────────────────────────
 Constants.BOOST_DURATION   = 2    -- seconds

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -33,17 +33,15 @@ local _totalRacers = 0
 local _physState = {}
 
 -- ─── Track axis ───────────────────────────────────────────────────────────────
--- Track runs along the Z axis from +600 (start) to -600 (finish).
--- Progress = distance travelled toward finish (higher = closer to finish).
-
-local TRACK_START_Z = 600
-local TRACK_END_Z   = -600
+-- Track runs along -Z. Per-biome zStart/zFinish live in Constants.TRACK and
+-- are looked up at race start from the active _biome.
 
 local function _trackProgress(vehicle)
-	if not vehicle or not vehicle.PrimaryPart then return 0 end
+	if not vehicle or not vehicle.PrimaryPart or not _biome then return 0 end
+	local track = Constants.TRACK[_biome]
+	if not track then return 0 end
 	local z = vehicle.PrimaryPart.Position.Z
-	-- Map Z from start (+600) toward end (-600) onto 0→1200
-	return math.clamp(TRACK_START_Z - z, 0, Constants.TRACK_LENGTH)
+	return math.clamp(track.zStart - z, 0, track.zStart - track.zFinish)
 end
 
 -- ─── Position sync loop ───────────────────────────────────────────────────────
@@ -224,7 +222,9 @@ local function _respawnVehicle(player)
 	local primary = vehicle.PrimaryPart
 	local progress = _trackProgress(vehicle)
 	-- Step back 30 studs so the player has room to regain speed.
-	local safeZ = TRACK_START_Z - math.max(progress - 30, 0)
+	local track = _biome and Constants.TRACK[_biome]
+	local zStart = track and track.zStart or 600
+	local safeZ = zStart - math.max(progress - 30, 0)
 	local y     = _spawnY() + 3   -- a little above surface to avoid clipping
 
 	-- Briefly anchor so the vehicle doesn't fall while being moved.


### PR DESCRIPTION
## Summary
- Replace global `TRACK_LENGTH=1200` / `TRACK_WIDTH=40` / `FINISH_Z=-1000` (all out of sync with built maps) with a per-biome `Constants.TRACK` table driven by the racetrack spec.
- Per-biome Z-extents and widths: FOREST 2600/40, OCEAN 2100/60, SKY 3500/50.
- `RacingManager._trackProgress` and `_respawnVehicle` now read `zStart`/`zFinish` from the active `_biome` instead of hardcoded constants.

Closes #127. Foundation for #128-#130 (per-biome map rebuilds).

## Test plan
- [ ] Studio: launch a FOREST race, drive forward, confirm position-sync progress climbs smoothly from 0 toward 2600 (not capped at 1200).
- [ ] Same for OCEAN (cap 2100) and SKY (cap 3500).
- [ ] Drive off the kill plane mid-race; respawn drops vehicle ~30 studs behind current progress on the same Z axis as the active biome's track.
- [ ] No `nil index` errors at race start in the server console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)