### PR TITLE
feat(#139): slot contract foundation (A/3)

### DIFF
--- a/roblox/ReplicatedStorage/Shared/ItemTypes.lua
+++ b/roblox/ReplicatedStorage/Shared/ItemTypes.lua
@@ -6,10 +6,18 @@
 local ItemTypes = {}
 
 -- ─── Slot Types ───────────────────────────────────────────────────────────────
+-- BODY/ENGINE/SPECIAL are item categories (each ItemTypes.ALL entry has one of these).
+-- MOBILITY/HEAD/TAIL are vehicle slots — they accept items from any category and
+-- only differ in where the item gets mounted on the assembled vehicle (see
+-- SlotMountConfig.lua). Declared here so CraftingManager.slotAssignments and
+-- VehicleBuilder._attachSlotItem share identifier strings.
 ItemTypes.SlotType = {
-	BODY    = "BODY",
-	ENGINE  = "ENGINE",
-	SPECIAL = "SPECIAL",
+	BODY     = "BODY",
+	ENGINE   = "ENGINE",
+	SPECIAL  = "SPECIAL",
+	MOBILITY = "MOBILITY",
+	HEAD     = "HEAD",
+	TAIL     = "TAIL",
 }
 
 -- ─── Item Registry ─────────────────────────────────────────────────────────────

--- a/roblox/ReplicatedStorage/Shared/SlotMountConfig.lua
+++ b/roblox/ReplicatedStorage/Shared/SlotMountConfig.lua
@@ -1,0 +1,69 @@
+-- SlotMountConfig.lua
+-- Per-biome, per-slot mount transform table consumed by VehicleBuilder.
+-- Declares where each crafted item should appear on the assembled vehicle.
+-- Resolves: Issue #139
+
+local V3 = Vector3.new
+local CF = CFrame.new
+
+local SlotMountConfig = {}
+
+-- ─── Mount table ──────────────────────────────────────────────────────────────
+-- Keys: slotName (BODY/ENGINE/SPECIAL/MOBILITY/HEAD/TAIL) → biome (FOREST/OCEAN/SKY).
+--   scale   — target longest-axis size in studs after bbox-normalized rescale
+--   offset  — local-space mount offset relative to the hidden physics anchor
+--   rot     — Vector3 of Euler angles (degrees) applied to the mounted clone
+--   pattern — "single" | "wheels4" | "sail" | "wings2" (consumed by _attachSlotItem)
+--
+-- Biome notes:
+--   FOREST anchor sits at chassis center, +Z is forward (vehicle LookVector).
+--   OCEAN  anchor sits at hull center, +Z forward.
+--   SKY    anchor sits at fuselage center, -Z is forward (legacy buildFlyer convention).
+
+SlotMountConfig.MOUNTS = {
+	BODY = {
+		FOREST = { scale = 7.0, offset = V3(0,  0.6, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+		OCEAN  = { scale = 8.0, offset = V3(0,  0.4, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+		SKY    = { scale = 7.5, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+	},
+
+	MOBILITY = {
+		FOREST = { scale = 1.6, offset = V3(0, -0.6, 0), rot = V3(0, 0, 90), pattern = "wheels4" },
+		OCEAN  = { scale = 3.5, offset = V3(0,  2.0, 0), rot = V3(0, 0, 0),  pattern = "sail" },
+		SKY    = { scale = 3.0, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0),  pattern = "wings2" },
+	},
+
+	ENGINE = {
+		FOREST = { scale = 2.0, offset = V3(0,  0.8, -2.5), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 2.0, offset = V3(0,  1.0, -3.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.8, offset = V3(0,  0.0,  2.5), rot = V3(0, 0, 0), pattern = "single" },
+	},
+
+	SPECIAL = {
+		FOREST = { scale = 2.0, offset = V3(0,  2.0,  0.5), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 2.0, offset = V3(0,  3.5,  0.5), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.8, offset = V3(0,  1.0,  0.0), rot = V3(0, 0, 0), pattern = "single" },
+	},
+
+	HEAD = {
+		FOREST = { scale = 1.8, offset = V3(0,  1.2,  3.0), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.8, offset = V3(0,  1.2,  4.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.8, offset = V3(0,  0.4, -4.0), rot = V3(0, 0, 0), pattern = "single" },
+	},
+
+	TAIL = {
+		FOREST = { scale = 1.8, offset = V3(0,  1.2, -3.0), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.8, offset = V3(0,  1.2, -4.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.8, offset = V3(0,  0.4,  3.0), rot = V3(0, 0, 0), pattern = "single" },
+	},
+}
+
+-- ─── API ──────────────────────────────────────────────────────────────────────
+
+function SlotMountConfig.get(slotName, biome)
+	local s = SlotMountConfig.MOUNTS[slotName]
+	if not s then return nil end
+	return s[biome]
+end
+
+return SlotMountConfig

--- a/roblox/ServerScriptService/CraftingManager.server.lua
+++ b/roblox/ServerScriptService/CraftingManager.server.lua
@@ -144,7 +144,8 @@ GameManager.onPhaseChanged(function(phase, biome)
 				local model = VehicleBuilder.build(
 					stats,
 					biome,
-					spawnGrid[i] or CFrame.new(i * 6, 2, 0)
+					spawnGrid[i] or CFrame.new(i * 6, 2, 0),
+					stats.slotAssignments
 				)
 
 				if model then


### PR DESCRIPTION
## Summary
- **CraftingManager bug fix**: pass `stats.slotAssignments` to `VehicleBuilder.build` (L144–148). Without this, `_attachItems` silently received `slots=nil` and the item-visual code path was dead — every vehicle showed only the procedural chassis
- **New `SlotMountConfig.lua`**: biome × slot mount transform table (`scale`, `offset`, `rot`, `pattern`) — centralised so `ItemConfig` stays slot-agnostic and PR B/C have a single place to tune visuals
- **ItemTypes.SlotType**: add `MOBILITY`, `HEAD`, `TAIL` identifiers so server-side and VehicleBuilder share canonical strings

## Context
PR A/3 of the VehicleBuilder visual redesign for #139. Stack:
- A — this PR: contract + bug fix (small, behaviour mostly unchanged — items finally attach instead of being silently dropped)
- B — BODY-driven chassis (BODY item replaces procedural box)
- C — MOBILITY/SPECIAL/HEAD/TAIL pattern dispatch (wheels4/sail/wings2/single)

## Test plan
- [ ] Run a race in any biome with a full craft; in Studio Explorer the spawned vehicle Model should now contain the 4-stud item clones welded to chassis (previously absent)
- [ ] No regression in race start, drive, finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)