### PR TITLE
fix: sync ItemConfig/AbilityConfig/ItemModelBuilder to renamed ENGINE items

### DIFF
--- a/roblox/ReplicatedStorage/Shared/ItemConfig.lua
+++ b/roblox/ReplicatedStorage/Shared/ItemConfig.lua
@@ -177,60 +177,68 @@ ItemConfig["Flower"] = {
 	shape      = "flower",
 }
 
-ItemConfig["Pinwheel"] = {
+ItemConfig["Alarm Clock"] = {
 	slotType   = "ENGINE",
 	rarity     = R.COMMON,
 	power      = 13,
-	icon       = "🌀",
-	shape      = "pinwheel",
+	icon       = "⏰",
+	shape      = "alarmclock",
 	biomeBonus = { SKY = 1.40, OCEAN = 1.20 },
 }
 
-ItemConfig["Watering Can"] = {
+ItemConfig["Magnifying Glass"] = {
 	slotType   = "ENGINE",
 	rarity     = R.UNCOMMON,
 	power      = 18,
-	icon       = "🚿",
-	shape      = "wateringcan",
+	icon       = "🔍",
+	shape      = "magnifyingglass",
 	biomeBonus = { OCEAN = 1.35 },
 }
 
 -- Big Gear removed in #88: power=8 too low for Uncommon, single gear doesn't read as engine visually
 -- Wind Turbine removed: never modeled, item not in roster
 
-ItemConfig["Leaf Blower"] = {
+ItemConfig["Hair Dryer"] = {
 	slotType   = "ENGINE",
 	rarity     = R.UNCOMMON,
 	power      = 20,
-	icon       = "💨",
-	shape      = "leafblower",
+	icon       = "💇",
+	shape      = "hairdryer",
 	biomeBonus = { SKY = 1.30 },
 }
 
-ItemConfig["Spinning Top"] = {
+ItemConfig["Compass"] = {
 	slotType   = "ENGINE",
 	rarity     = R.RARE,
 	power      = 22,
-	icon       = "🪀",
-	shape      = "spinningtop",
-	-- high power but direction randomness penalty handled in AbilityConfig
+	icon       = "🧭",
+	shape      = "compass",
 }
 
-ItemConfig["Propeller"] = {
+ItemConfig["Propeller Hat"] = {
 	slotType   = "ENGINE",
 	rarity     = R.RARE,
 	power      = 15,
-	icon       = "🚁",
-	shape      = "propeller",
+	icon       = "🎩",
+	shape      = "propellerhat",
 	biomeBonus = { SKY = 1.20 },
 }
 
-ItemConfig["V8 Engine"] = {
+ItemConfig["Treadmill"] = {
 	slotType   = "ENGINE",
 	rarity     = R.RARE,
 	power      = 25,
-	icon       = "🏎️",
-	shape      = "engine",
+	icon       = "🏃",
+	shape      = "treadmill",
+}
+
+ItemConfig["Drill"] = {
+	slotType   = "ENGINE",
+	rarity     = R.RARE,
+	power      = 22,
+	icon       = "🪛",
+	shape      = "drill",
+	biomeBonus = { FOREST = 1.25 },
 }
 
 ItemConfig["Rocket"] = {

--- a/roblox/ServerScriptService/Modules/AbilityConfig.lua
+++ b/roblox/ServerScriptService/Modules/AbilityConfig.lua
@@ -245,24 +245,24 @@ AbilityConfig["Flower"] = {
 -- Big Gear removed in #88 (power=8 underwhelming, single gear doesn't read as engine)
 -- Wind Turbine removed: never modeled, item not in roster
 
-AbilityConfig["Propeller"] = {
+AbilityConfig["Propeller Hat"] = {
 	cooldown    = 12,
 	duration    = 2,
 	targetType  = "self",
 	effectKey   = "hover",        -- BodyForce upward; ignore ground hazards
 	animKey     = "propHover",
 	sfxKey      = "propeller_spin",
-	uiHint      = "🚁 Hover!",
+	uiHint      = "🎩 Hover!",
 }
 
-AbilityConfig["V8 Engine"] = {
+AbilityConfig["Treadmill"] = {
 	cooldown    = 12,
 	duration    = 2,
 	targetType  = "self",
 	effectKey   = "redline",      -- instant max speed; A/D disabled
 	animKey     = "v8Rev",
 	sfxKey      = "v8_roar",
-	uiHint      = "🏎️ Redline!",
+	uiHint      = "🏃 Redline!",
 }
 
 AbilityConfig["Kettle"] = {
@@ -295,7 +295,7 @@ AbilityConfig["Rocket"] = {
 	uiHint      = "🚀 IGNITE!",
 }
 
-AbilityConfig["Leaf Blower"] = {
+AbilityConfig["Hair Dryer"] = {
 	cooldown    = 18,
 	duration    = 1,
 	targetType  = "all_in_radius",
@@ -303,40 +303,40 @@ AbilityConfig["Leaf Blower"] = {
 	effectKey   = "windBlast",    -- pushes nearby vehicles laterally
 	animKey     = "leafBlowerOn",
 	sfxKey      = "leafblower_blast",
-	uiHint      = "💨 Blast!",
+	uiHint      = "💇 Blast!",
 }
 
-AbilityConfig["Watering Can"] = {
+AbilityConfig["Magnifying Glass"] = {
 	cooldown    = 15,
 	duration    = 2,
 	targetType  = "track_drop",
 	effectKey   = "waterPuddle",  -- OCEAN bonus: bigger + floatability drain
 	animKey     = "waterPour",
 	sfxKey      = "water_pour",
-	uiHint      = "🚿 Flood!",
+	uiHint      = "🔍 Flood!",
 	biomeEffect = {
 		OCEAN = { effectKey = "waterPuddleLarge", radius = 8, duration = 3 },
 	},
 }
 
-AbilityConfig["Spinning Top"] = {
+AbilityConfig["Compass"] = {
 	cooldown    = 12,
 	duration    = 2,
 	targetType  = "self",
 	effectKey   = "spinBurst",    -- high speed burst with random directional wobble
 	animKey     = "topSpin",
 	sfxKey      = "top_spin",
-	uiHint      = "🪀 Spin!",
+	uiHint      = "🧭 Spin!",
 }
 
-AbilityConfig["Pinwheel"] = {
+AbilityConfig["Alarm Clock"] = {
 	cooldown    = 14,
 	duration    = 3,
 	targetType  = "self",
 	effectKey   = "windRide",     -- strong biome bonus for SKY/OCEAN
 	animKey     = "pinwheelSpin",
 	sfxKey      = "pinwheel_spin",
-	uiHint      = "🌀 Wind!",
+	uiHint      = "⏰ Wind!",
 }
 
 -- ── BODY tier ─────────────────────────────────────────────────────────────────

--- a/roblox/ServerScriptService/Modules/ItemModelBuilder.lua
+++ b/roblox/ServerScriptService/Modules/ItemModelBuilder.lua
@@ -1003,19 +1003,24 @@ local BUILDERS = {
 	["Red Sofa"]       = _buildSofa,
 	["Microwave"]      = _buildMicrowave,
 	["Bathtub"]        = _buildBathtub,
-	-- ENGINE (12): Fan + Hand Mixer added in #89/#116; Shovel + Big Gear + Wind Turbine removed
-	["Fan"]            = _buildFan,
-	["Flower"]         = _buildFlower,
-	["Pinwheel"]       = _buildPinwheel,
-	["Watering Can"]   = _buildWateringCan,
-	["Drill"]          = _buildDrill,
-	["Leaf Blower"]    = _buildLeafBlower,
-	["Spinning Top"]   = _buildSpinningTop,
-	["Propeller"]      = _buildPropeller,
-	["V8 Engine"]      = _buildV8Engine,
-	["Rocket"]         = _buildRocket,
-	["Cup Noodle"]     = _buildCupNoodle,
-	["Kettle"]         = _buildKettle,
+	-- ENGINE (12): 6 renamed in 8f35e80 (Leaf Blower→Hair Dryer, Pinwheel→Alarm
+	-- Clock, Propeller→Propeller Hat, Spinning Top→Compass, V8 Engine→Treadmill,
+	-- Watering Can→Magnifying Glass). The procedural builder shapes don't match
+	-- the new names but at least the items have *some* visible mesh now instead
+	-- of falling to the unbuilt grey-cube fallback. Replace these procedurals
+	-- with the matching FBX once each is imported into ServerStorage.ItemMeshes.
+	["Fan"]               = _buildFan,
+	["Flower"]            = _buildFlower,
+	["Alarm Clock"]       = _buildPinwheel,
+	["Magnifying Glass"]  = _buildWateringCan,
+	["Drill"]             = _buildDrill,
+	["Hair Dryer"]        = _buildLeafBlower,
+	["Compass"]           = _buildSpinningTop,
+	["Propeller Hat"]     = _buildPropeller,
+	["Treadmill"]         = _buildV8Engine,
+	["Rocket"]            = _buildRocket,
+	["Cup Noodle"]        = _buildCupNoodle,
+	["Kettle"]            = _buildKettle,
 	-- SPECIAL (14): Oil Can/Boombox/Bubble Wrap/Firework removed in SPECIAL overhaul;
 	-- Gas Can/Lantern/Camera/Magic Wand/Trophy use FBX-only (fallback = labeled cube)
 	["Pizza"]          = _buildPizza,


### PR DESCRIPTION
## Summary
Commit 8f35e80 renamed 6 ENGINE items in `ItemTypes.lua` but the stat/ability/procedural-builder tables still used the old names. Crafting a renamed item had nil stats and no procedural mesh, falling through to the unbuilt grey-cube fallback. ItemVisualUpgrader then drew a Rare-tier blue glow ring around it — the cyan-glowing cube of unknown identity you saw on the farming map.

Mapping per 8f35e80:
- Leaf Blower → Hair Dryer
- Pinwheel → Alarm Clock
- Propeller → Propeller Hat
- Spinning Top → Compass
- V8 Engine → Treadmill
- Watering Can → Magnifying Glass
- Drill (new in #122) — added to ItemConfig

Procedural builder shapes don't match the new names (Hair Dryer still looks like a leaf blower) — these are stopgaps so the items have *some* mesh until each new FBX gets imported into `ServerStorage.ItemMeshes`.

## Test plan
- [ ] In Studio, farm any renamed ENGINE item. Confirm it has a visible mesh + nameplate.
- [ ] Craft a vehicle with each renamed ENGINE item → SubmitCraft returns "ok", stats panel shows non-zero power.
- [ ] Trigger the ability key on a renamed item → AbilityConfig lookup succeeds, ability fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)