### PR TITLE
fix: farming pickup, toast dismiss, SKY steering, vehicle seating

### DIFF
--- a/roblox/ServerScriptService/CraftingManager.server.lua
+++ b/roblox/ServerScriptService/CraftingManager.server.lua
@@ -172,12 +172,34 @@ GameManager.onPhaseChanged(function(phase, biome)
 					if seat then
 						print(string.format("[CraftingManager] Vehicle for %s spawned at %s | seat=%s",
 							player.Name, tostring(primary and primary.Position), tostring(seat)))
-						-- Seat player BEFORE firing VehicleSpawned so the drive loop
-						-- starts only after the character is already welded to the seat.
-						if player.Character then
-							seat:Sit(player.Character:FindFirstChild("Humanoid"))
+
+						-- Wait for character + humanoid to be ready. RACING can
+						-- start while the player is mid-respawn from the FARMING/
+						-- CRAFTING transition; firing Sit before the humanoid
+						-- exists silently fails and leaves the player standing
+						-- on the spawn pad with the vehicle invisible underneath.
+						local humanoid = nil
+						local deadline = tick() + 2
+						repeat
+							humanoid = player.Character and player.Character:FindFirstChildOfClass("Humanoid")
+							if not humanoid then task.wait(0.05) end
+						until humanoid or tick() > deadline
+
+						if humanoid then
+							seat:Sit(humanoid)
+							task.wait(0.15)  -- let weld settle
+							-- Verify the sit actually took. Humanoid.Sit becomes
+							-- true once Roblox wires up the SeatWeld; if it's
+							-- still false the seat:Sit silently failed (common
+							-- if the humanoid was mid-Climb/Jump). Retry once.
+							if not humanoid.Sit then
+								seat:Sit(humanoid)
+								task.wait(0.1)
+							end
+						else
+							warn("[CraftingManager] Humanoid never ready for", player.Name)
 						end
-						task.wait(0.1)  -- let weld settle
+
 						RemoteEvents.VehicleSpawned:FireClient(player, player.UserId, model)
 						-- Unanchor after sit takes effect so vehicle can move
 						task.wait(0.1)

--- a/roblox/ServerScriptService/FarmingManager.server.lua
+++ b/roblox/ServerScriptService/FarmingManager.server.lua
@@ -429,14 +429,28 @@ RemoteEvents.RequestPickup.OnServerInvoke = function(player, itemId)
 		end
 	end
 
-	-- Distance check
+	-- Distance check — measured to the closest BasePart in the model, not just
+	-- PrimaryPart. FBX-imported models can have PrimaryPart offset from the
+	-- visible mesh; using the model's nearest point matches the client-side
+	-- prompt range and avoids "denied: too far" when the player is clearly
+	-- touching the item.
 	local char = player.Character
 	local root = char and char:FindFirstChild("HumanoidRootPart")
 	if not root then return "denied: no character" end
 
-	local dist = (root.Position - item.part.Position).Magnitude
-	if dist > Constants.PICKUP_RANGE then
-		return "denied: too far (" .. math.floor(dist) .. " studs)"
+	local closestDist = math.huge
+	if item.model then
+		for _, p in ipairs(item.model:GetDescendants()) do
+			if p:IsA("BasePart") then
+				local d = (root.Position - p.Position).Magnitude
+				if d < closestDist then closestDist = d end
+			end
+		end
+	else
+		closestDist = (root.Position - item.part.Position).Magnitude
+	end
+	if closestDist > Constants.PICKUP_RANGE then
+		return "denied: too far (" .. math.floor(closestDist) .. " studs)"
 	end
 
 	-- Check if another player is also in range → start contest

--- a/roblox/StarterGui/TutorialUI/init.client.lua
+++ b/roblox/StarterGui/TutorialUI/init.client.lua
@@ -202,11 +202,42 @@ end
 
 -- ─── Show toast ───────────────────────────────────────────────────────────────
 
-local _toastTimer = nil
+local _toastTimer  = nil
+local _toastHideTimer = nil
+
+local function _hideToast()
+	if _toastTimer then
+		pcall(task.cancel, _toastTimer)
+		_toastTimer = nil
+	end
+	if _toastHideTimer then
+		pcall(task.cancel, _toastHideTimer)
+		_toastHideTimer = nil
+	end
+	if not toastFrame.Visible then return end
+	TweenService:Create(toastFrame, TweenInfo.new(0.25, Enum.EasingStyle.Quad, Enum.EasingDirection.In), {
+		Position = UDim2.new(0.5, -180, 0, 40)
+	}):Play()
+	_toastHideTimer = task.delay(0.25, function()
+		toastFrame.Visible = false
+		_toastHideTimer = nil
+	end)
+end
 
 local function _showToast(phase)
 	local guide = PHASE_GUIDES[phase]
-	if not guide then return end
+	if not guide then
+		-- Phases without a guide (e.g. RESULTS, LOBBY) should clear any
+		-- lingering toast so it doesn't persist across phase changes.
+		_hideToast()
+		return
+	end
+
+	-- Cancel any pending hide so we don't immediately tween the new toast away.
+	if _toastHideTimer then
+		pcall(task.cancel, _toastHideTimer)
+		_toastHideTimer = nil
+	end
 
 	-- Populate content
 	toastAccent.BackgroundColor3 = guide.colour
@@ -227,14 +258,22 @@ local function _showToast(phase)
 	}):Play()
 
 	-- Auto-hide after 7s
-	if _toastTimer then task.cancel(_toastTimer) end
+	if _toastTimer then pcall(task.cancel, _toastTimer) end
 	_toastTimer = task.delay(7, function()
-		TweenService:Create(toastFrame, TweenInfo.new(0.3, Enum.EasingStyle.Quad, Enum.EasingDirection.In), {
-			Position = UDim2.new(0.5, -180, 0, 40)
-		}):Play()
-		task.delay(0.3, function() toastFrame.Visible = false end)
+		_toastTimer = nil
+		_hideToast()
 	end)
 end
+
+-- Click anywhere on the toast to dismiss early.
+local clickCatcher = Instance.new("TextButton")
+clickCatcher.Size                  = UDim2.fromScale(1, 1)
+clickCatcher.BackgroundTransparency = 1
+clickCatcher.Text                  = ""
+clickCatcher.AutoButtonColor       = false
+clickCatcher.ZIndex                = 10
+clickCatcher.Parent                = toastFrame
+clickCatcher.Activated:Connect(_hideToast)
 
 -- ─── Full reference panel (F1 toggle) ────────────────────────────────────────
 

--- a/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/FarmingClient.client.lua
@@ -80,15 +80,27 @@ local function _scanNearby()
 	local nearestPlayer = nil
 	local nearestPlayerDist = math.huge
 
-	-- Scan items: FarmingManager places a StringValue named "ItemName" on each
-	-- item's PrimaryPart, so we detect items by that value rather than by name prefix.
+	-- Scan items: FarmingManager places a StringValue named "ItemName" on the
+	-- item model's PrimaryPart. FBX-imported items can have the PrimaryPart
+	-- offset from the visible mesh center, so we walk up from any part returned
+	-- by the bounds check and resolve the containing item's PrimaryPart. This
+	-- way ANY part of the model touching the radius triggers detection.
+	local seenPrimary = {}
 	local parts = workspace:GetPartBoundsInRadius(root.Position, Constants.PICKUP_RANGE)
 	for _, part in ipairs(parts) do
-		if part:FindFirstChild("ItemName") then
-			local d = (part.Position - root.Position).Magnitude
-			if d < nearestItemDist then
-				nearestItemDist = d
-				nearestItem = part
+		local node = part
+		while node and node.Parent and not node:IsA("Model") do
+			node = node.Parent
+		end
+		if node and node:IsA("Model") and node.PrimaryPart then
+			local primary = node.PrimaryPart
+			if primary:FindFirstChild("ItemName") and not seenPrimary[primary] then
+				seenPrimary[primary] = true
+				local d = (primary.Position - root.Position).Magnitude
+				if d < nearestItemDist then
+					nearestItemDist = d
+					nearestItem = primary
+				end
 			end
 		end
 	end

--- a/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
@@ -338,16 +338,22 @@ local function _driveLoop()
 	local turnSpeed = _seat and _seat.TurnSpeed or 1
 	local throttle, steer
 
-	if _biome == "SKY" then
-		throttle = 0
-		if _keys.W or _keys.Up   then throttle =  1 end
-		if _keys.S or _keys.Down then throttle = -0.5 end
-		steer = 0
-		if _keys.A or _keys.Left  then steer =  1 end
-		if _keys.D or _keys.Right then steer = -1 end
-		turnSpeed = math.min(turnSpeed, 1.5)
+	-- Detect SKY mode by the vehicle's HoverPosition constraint rather than
+	-- the _biome client variable. BiomeSelected can race against PhaseChanged
+	-- on client load and leave _biome nil/stale — but the vehicle is
+	-- authoritative about its own physics setup.
+	local hover = primary:FindFirstChild("HoverPosition")
+	local isSky = hover ~= nil
 
-		local hover = primary:FindFirstChild("HoverPosition")
+	throttle = 0
+	if _keys.W or _keys.Up   then throttle =  1 end
+	if _keys.S or _keys.Down then throttle = -0.5 end
+	steer = 0
+	if _keys.A or _keys.Left  then steer =  1 end
+	if _keys.D or _keys.Right then steer = -1 end
+
+	if isSky then
+		turnSpeed = math.min(turnSpeed, 1.5)
 		if hover then
 			local dt = 1 / 60
 			if _keys.Space then
@@ -357,13 +363,6 @@ local function _driveLoop()
 			end
 		end
 	else
-		if not _seat then return end
-		throttle = 0
-		if _keys.W or _keys.Up   then throttle =  1 end
-		if _keys.S or _keys.Down then throttle = -0.5 end
-		steer = 0
-		if _keys.A or _keys.Left  then steer =  1 end
-		if _keys.D or _keys.Right then steer = -1 end
 
 		local isSteering = _keys.A or _keys.D or _keys.Left or _keys.Right
 		if _keys.Shift and isSteering and not _drifting then


### PR DESCRIPTION
## Summary

Four user-reported bugs from a single play session, fixed together since each is small and they share no architecture:

- **Farming E prompt**: didn't appear next to FBX-imported items because the radius scan tested ItemName on each returned BasePart, but ItemName only sits on the model's PrimaryPart (which can be deep inside the visible mesh). Walk up to the containing Model. Server-side pickup distance now matches by measuring to the nearest BasePart in the model.
- **Phase-start toast**: didn't auto-dismiss because phase changes without a guide (RESULTS) didn't clear the previous toast. Always hide on phase change; added click-anywhere-to-dismiss.
- **SKY A/D doesn't steer**: \`_biome\` could be nil if BiomeSelected raced PhaseChanged on first load, so the SKY branch never ran. Detect SKY by the vehicle's HoverPosition constraint instead. Removed an unnecessary early-return so steering doesn't depend on _seat being wired.
- **Player on spawn pad instead of in vehicle**: \`seat:Sit\` was called once, immediately; humanoid wasn't always ready at race start. Wait up to 2s for the humanoid, then verify Humanoid.Sit and retry once.

## Test plan
- [ ] FOREST: walk near a barrel → \`[E] Pick Up\` prompt appears; press E picks up.
- [ ] OCEAN/SKY: same — prompt appears next to FBX-imported items where it didn't before.
- [ ] Phase change FARMING→CRAFTING: toast for new phase appears, previous one not stuck.
- [ ] Click on toast: dismisses immediately.
- [ ] Wait 7s on a toast: auto-dismisses.
- [ ] SKY race: A/D yaws the flyer (was previously dead in some sessions).
- [ ] Any biome race start: player is seated in the vehicle, not standing on a spawn pad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)