### PR TITLE
fix: phase-start toast appears empty (regression from #144)

### DIFF
--- a/roblox/StarterGui/TutorialUI/init.client.lua
+++ b/roblox/StarterGui/TutorialUI/init.client.lua
@@ -266,14 +266,17 @@ local function _showToast(phase)
 end
 
 -- Click anywhere on the toast to dismiss early.
-local clickCatcher = Instance.new("TextButton")
-clickCatcher.Size                  = UDim2.fromScale(1, 1)
-clickCatcher.BackgroundTransparency = 1
-clickCatcher.Text                  = ""
-clickCatcher.AutoButtonColor       = false
-clickCatcher.ZIndex                = 10
-clickCatcher.Parent                = toastFrame
-clickCatcher.Activated:Connect(_hideToast)
+-- A child TextButton with Size=fromScale(1,1) would participate in the
+-- toastFrame's UIListLayout and push all the actual content (title, key
+-- rows, tip) out of the visible region — that's exactly the empty-toast
+-- bug introduced in #144. Listen for input on the frame itself instead.
+toastFrame.Active = true
+toastFrame.InputBegan:Connect(function(input)
+	if input.UserInputType == Enum.UserInputType.MouseButton1
+		or input.UserInputType == Enum.UserInputType.Touch then
+		_hideToast()
+	end
+end)
 
 -- ─── Full reference panel (F1 toggle) ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

In PR #144 I added a click-to-dismiss TextButton inside the toast frame to make the phase-start toast dismissable. But \`toastFrame\` uses a \`UIListLayout\` to stack its content rows, so a child with \`Size = UDim2.fromScale(1,1)\` and the default \`LayoutOrder = 0\` ended up as a 100%×100% layout participant that pushed the title, keys, tip, and dismiss-footer rows out of the visible region. Result: the toast renders as a tall dark empty frame.

Fix: drop the child button entirely. Set \`toastFrame.Active = true\` and bind \`InputBegan\` (mouse + touch) on the frame itself to call \`_hideToast()\`. Same dismissal behavior, no layout participation.

## Test plan
- [ ] Enter RACING phase → toast shows title, all key rows, tip, and dismiss-footer text (the regression from #144).
- [ ] Click on the toast → it dismisses immediately.
- [ ] Wait 7s without clicking → it auto-dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)