### PR TITLE
fix: vehicle spin when items mounted + remove rarity highlight

### DIFF
--- a/roblox/ServerScriptService/Modules/ItemVisualUpgrader.lua
+++ b/roblox/ServerScriptService/Modules/ItemVisualUpgrader.lua
@@ -229,28 +229,13 @@ function ItemVisualUpgrader.apply(model, rarity)
 	local primary = model.PrimaryPart
 	if not primary then return end
 
-	-- 1. Reflectance
-	if cfg.reflectance > 0 then
-		_upgradeReflectance(model, cfg.reflectance)
-	end
+	-- All rarity-specific visual effects (reflectance bump, glow ring,
+	-- particle aura, Epic orbit orbs) are intentionally disabled. User
+	-- feedback: the highlighting on farmable items was distracting and
+	-- hard to read against FBX-imported geometry. Rarity is now signalled
+	-- only by the name-label colour rendered by FarmingClient.
 
-	-- Glow ring removed: the thin neon band sat at primary.CFrame and cut
-	-- visually through FBX-imported items (e.g. a Camera with a bright green
-	-- band slicing through the lens). Rarity is now communicated by particle
-	-- aura (Rare+), reflectance bump (Uncommon+), and the rarity-coloured
-	-- name label rendered by FarmingClient's item label system.
-
-	-- 3. Particle aura (Rare+)
-	if cfg.particles then
-		_addParticleAura(primary, cfg)
-	end
-
-	-- 4. Epic orbit orbs
-	if cfg.orbits then
-		_addEpicOrbs(model, primary)
-	end
-
-	-- 5. Idle float + rotate
+	-- Idle float + rotate keeps items feeling alive without colour highlight.
 	local floatConn = _addIdleFloat(primary, cfg)
 
 	return floatConn

--- a/roblox/ServerScriptService/Modules/VehicleBuilder.lua
+++ b/roblox/ServerScriptService/Modules/VehicleBuilder.lua
@@ -97,6 +97,13 @@ local function itemVisual(itemName, attachCF, model)
 			if p:IsA("BasePart") then
 				p.CFrame     = delta * p.CFrame
 				p.CanCollide = false
+				-- Massless: items are decorations and must not contribute to the
+				-- assembly's mass distribution. FBX items have asymmetric mass
+				-- (e.g. Camera lens to one side); when weighted into the chassis
+				-- they shifted COM laterally, so BodyVelocity along LookVector
+				-- created torque around the offset COM and the vehicle spun in
+				-- place instead of driving forward.
+				p.Massless   = true
 			end
 		end
 		clone.Parent = model
@@ -106,7 +113,9 @@ local function itemVisual(itemName, attachCF, model)
 	-- Fallback: simple coloured block
 	local size = Vector3.new(0.9, 0.9, 0.9)
 	local part = block(size, attachCF, colour, Enum.Material.Neon, model)
-	part.Name  = "Item_" .. itemName
+	part.Name      = "Item_" .. itemName
+	part.CanCollide = false
+	part.Massless   = true
 
 	-- Label billboard
 	local bb = Instance.new("BillboardGui")


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs from playtesting:

### 1. Pressing W made the vehicle spin in place
Once #140 wired slot items through to \`VehicleBuilder\`, item models started actually mounting on the chassis. FBX-imported items have asymmetric mass distributions (e.g. a Camera with the lens off-centre). When welded into the chassis assembly they shifted the centre of mass laterally, so \`BodyVelocity\` applied at the chassis centre created torque around the offset COM and the vehicle yawed instead of driving forward.

Fix: \`p.Massless = true\` for every item \`BasePart\` in both the FBX-template path and the procedural fallback. Items remain visible but contribute no mass.

### 2. Rarity highlight on farmable items removed
User feedback: the rarity glow was distracting and hard to read against FBX geometry. \`ItemVisualUpgrader.apply\` now skips reflectance bump, particle aura, and Epic orbit orbs. Only the idle float animation remains. Rarity is communicated solely by the name-label colour rendered by FarmingClient.

## Test plan
- [ ] Race in FOREST with a filled vehicle: W drives forward, no spin.
- [ ] Race in OCEAN with a filled vehicle: same.
- [ ] Race in SKY with a filled vehicle: same; turn keys still work.
- [ ] Race with empty slots: still works (regression check).
- [ ] During FARMING phase, items have no glow/particles/orbs — just gentle hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)