### PR TITLE
fix: dropped items appear as cubes instead of FBX models

### DIFF
--- a/roblox/ServerScriptService/FarmingManager.server.lua
+++ b/roblox/ServerScriptService/FarmingManager.server.lua
@@ -29,6 +29,16 @@ local _phaseTimer = nil
 local _active     = false
 local _itemCounter = 0   -- monotonic ID so every spawned part gets a unique key
 
+-- Per-biome farm zone constants. Hardcoded baseY values match the surface Y
+-- each MapBuilder uses for its farm ground; bounding-box inference is unreliable
+-- (tall trees skew Y, water planes skew X/Z). Lifted to module scope so both
+-- _spawnItems and _dropItem can resolve the correct ground Y for the active biome.
+local BIOME_ZONES = {
+	FOREST = { cx=0, cz=350, halfX=80, halfZ=120, baseY=1.0 },  -- FarmGround surface Y=1
+	OCEAN  = { cx=0, cz=375, halfX=55, halfZ=90,  baseY=5.0 },  -- FarmGrass surface Y=5 (WATER_Y+2.5+0.5)
+	SKY    = { cx=0, cz=390, halfX=35, halfZ=70,  baseY=80.0 }, -- FarmPlatform surface Y=80
+}
+
 -- ─── Weighted spawn pool ──────────────────────────────────────────────────────
 
 local function _buildSpawnPool()
@@ -72,14 +82,6 @@ local function _spawnItems(biome)
 	-- and height for their biome — using them avoids hardcoded coordinates that
 	-- break for SKY (floating platforms) and OCEAN (elevated dock/island).
 	local spawnCX, spawnCZ, halfX, halfZ, baseY
-
-	-- Per-biome hardcoded spawn zones that match each MapBuilder's farm area exactly.
-	-- Bounding-box inference is unreliable (tall trees skew Y; water planes skew X/Z).
-	local BIOME_ZONES = {
-		FOREST = { cx=0, cz=350, halfX=80, halfZ=120, baseY=1.0 },  -- FarmGround surface Y=1
-		OCEAN  = { cx=0, cz=375, halfX=55, halfZ=90,  baseY=5.0 },  -- FarmGrass surface Y=5 (WATER_Y+2.5+0.5)
-		SKY    = { cx=0, cz=390, halfX=35, halfZ=70,  baseY=80.0 }, -- FarmPlatform surface Y=80
-	}
 
 	-- Always use hardcoded baseY: bounding-box Y is skewed by tall objects (barn, trees).
 	local zone = BIOME_ZONES[biome] or BIOME_ZONES.FOREST
@@ -291,16 +293,29 @@ local function _dropItem(player, slotIndex)
 	local cfg = ItemConfig[itemName]
 
 	-- Spawn a new world item near the player
-	local char = player.Character
-	local root = char and char:FindFirstChild("HumanoidRootPart")
-	local spawnPos = root and (root.Position + Vector3.new(math.random(-3,3), 0, math.random(-3,3)))
-		or Vector3.new(0, 5, 0)
-
-	local mapName  = (_active and (function()
+	local biome = (_active and (function()
 		local gm = require(game.ServerScriptService.GameManager)
 		return gm.getBiome()
 	end)()) or "FOREST"
-	mapName = mapName:sub(1,1):upper() .. mapName:sub(2):lower() .. "Map"
+	local biomeZone = BIOME_ZONES[biome] or BIOME_ZONES.FOREST
+
+	local char = player.Character
+	local root = char and char:FindFirstChild("HumanoidRootPart")
+	-- Anchor spawn Y to the biome's farm ground. The previous version used
+	-- root.Position.Y, but HumanoidRootPart sits ~2.5 studs above the floor,
+	-- so dropped items reappeared floating in mid-air.
+	local spawnPos
+	if root then
+		spawnPos = Vector3.new(
+			root.Position.X + math.random(-3, 3),
+			biomeZone.baseY,
+			root.Position.Z + math.random(-3, 3)
+		)
+	else
+		spawnPos = Vector3.new(0, biomeZone.baseY, 0)
+	end
+
+	local mapName  = biome:sub(1,1):upper() .. biome:sub(2):lower() .. "Map"
 	local mapModel = game.Workspace:FindFirstChild("Maps")
 		and game.Workspace.Maps:FindFirstChild(mapName)
 
@@ -373,6 +388,32 @@ local function _dropItem(player, slotIndex)
 	rarVal.Name = "Rarity"; rarVal.Value = rarity; rarVal.Parent = primary
 
 	pcall(function() ItemVisualUpgrader.apply(model, rarity) end)
+
+	-- Name label (same widget as _spawnItems). Without this, dropped items
+	-- reappeared as anonymous meshes with no rarity colour cue.
+	local billboard = Instance.new("BillboardGui")
+	billboard.Name           = "NameTag"
+	billboard.Size           = UDim2.new(0, 110, 0, 22)
+	billboard.StudsOffset    = Vector3.new(0, 2.4, 0)
+	billboard.AlwaysOnTop    = false
+	billboard.MaxDistance    = 35
+	billboard.LightInfluence = 0
+	billboard.Parent         = primary
+
+	local nameLbl = Instance.new("TextLabel")
+	nameLbl.Size                    = UDim2.fromScale(1, 1)
+	nameLbl.BackgroundTransparency  = 1
+	nameLbl.Text                    = ((cfg and cfg.icon) and (cfg.icon .. " ") or "") .. itemName
+	nameLbl.TextScaled              = true
+	nameLbl.Font                    = Enum.Font.GothamBold
+	nameLbl.TextStrokeTransparency  = 0.4
+	nameLbl.TextColor3              = ({
+		Common   = Color3.fromRGB(220, 220, 220),
+		Uncommon = Color3.fromRGB(110, 230, 110),
+		Rare     = Color3.fromRGB(120, 170, 255),
+		Epic     = Color3.fromRGB(210, 130, 255),
+	})[rarity] or Color3.new(1, 1, 1)
+	nameLbl.Parent                  = billboard
 
 	_itemCounter = _itemCounter + 1
 	local itemId = tostring(_itemCounter)

--- a/roblox/ServerScriptService/FarmingManager.server.lua
+++ b/roblox/ServerScriptService/FarmingManager.server.lua
@@ -304,9 +304,20 @@ local function _dropItem(player, slotIndex)
 	local mapModel = game.Workspace:FindFirstChild("Maps")
 		and game.Workspace.Maps:FindFirstChild(mapName)
 
+	-- Clone the preloaded FBX template the same way _spawnItems does. The
+	-- previous code went straight to ItemModelBuilder.build, which is the
+	-- procedural-cube fallback — so any item dropped via auto-swap or the
+	-- Q key reappeared as a white block instead of its real mesh.
 	local model
 	local ok, err = pcall(function()
-		model = ItemModelBuilder.build(itemName, mapModel or game.Workspace)
+		local itemModels = ServerStorage:FindFirstChild("ItemModels")
+		local prebuilt   = itemModels and itemModels:FindFirstChild(itemName)
+		if prebuilt then
+			model        = prebuilt:Clone()
+			model.Parent = mapModel or game.Workspace
+		else
+			model = ItemModelBuilder.build(itemName, mapModel or game.Workspace)
+		end
 	end)
 	if not ok or not model or not model.PrimaryPart then
 		if model then model:Destroy() end
@@ -315,11 +326,32 @@ local function _dropItem(player, slotIndex)
 	end
 
 	local primary = model.PrimaryPart
+	-- Anchor before translating: FBX clones come out with WeldConstraints,
+	-- and setting CFrame on an unanchored welded part snaps welds and
+	-- scatters children. Same precaution as _spawnItems.
+	for _, part in ipairs(model:GetDescendants()) do
+		if part:IsA("BasePart") then
+			part.Anchored   = true
+			part.CanCollide = false
+		end
+	end
+	-- 8-corner world-space bottom-Y so rotated subparts (common in FBX) sit
+	-- flush on the ground instead of half-buried.
 	local minBottomY = math.huge
 	for _, part in ipairs(model:GetDescendants()) do
 		if part:IsA("BasePart") then
-			local b = part.Position.Y - part.Size.Y * 0.5
-			if b < minBottomY then minBottomY = b end
+			local cf  = part.CFrame
+			local hsx = part.Size.X * 0.5
+			local hsy = part.Size.Y * 0.5
+			local hsz = part.Size.Z * 0.5
+			for sx = -1, 1, 2 do
+				for sy = -1, 1, 2 do
+					for sz = -1, 1, 2 do
+						local corner = cf * Vector3.new(sx * hsx, sy * hsy, sz * hsz)
+						if corner.Y < minBottomY then minBottomY = corner.Y end
+					end
+				end
+			end
 		end
 	end
 	local deltaPos = Vector3.new(
@@ -329,9 +361,7 @@ local function _dropItem(player, slotIndex)
 	)
 	for _, part in ipairs(model:GetDescendants()) do
 		if part:IsA("BasePart") then
-			part.CFrame     = part.CFrame + deltaPos
-			part.Anchored   = true
-			part.CanCollide = false
+			part.CFrame = part.CFrame + deltaPos
 		end
 	end
 


### PR DESCRIPTION
## Summary
- 인벤토리에서 떨어뜨린 아이템이 흰색 정육면체로 보이는 버그 수정 (이미지: Drill은 정상, Lantern은 큐브).
- 풀-인벤토리 auto-swap과 Q 키 수동 드롭 모두 `_dropItem` → `ItemModelBuilder.build`(절차적 큐브 fallback)로 흘러서 FBX 메시 대신 블록이 스폰됐다.
- `_spawnItems`와 동일하게 `ServerStorage.ItemModels/<itemName>` 템플릿을 clone하도록 변경. preloaded 템플릿이 없을 때만 builder fallback.
- FBX clone은 WeldConstraint를 포함하므로 translate 전 anchor 필수, bottom-Y는 8-corner CFrame 계산으로 회전된 subpart도 지면에 flush.

## Test plan
- [ ] Studio 실행 → 인벤토리 가득 채운 뒤 더 좋은 rarity 아이템 줍기 → 자동 드롭된 약한 아이템이 원본 FBX 메시로 보이는지 확인 (Lantern, Camera 등).
- [ ] Q 키로 수동 드롭 → 같은 결과 확인.
- [ ] Preloader에 모델이 없는 가상 케이스는 기존 builder fallback이 동작해야 함 (regression 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)