### PR TITLE
fix: vehicle persists into next round after Play Again

### DIFF
--- a/roblox/ServerScriptService/SessionManager.lua
+++ b/roblox/ServerScriptService/SessionManager.lua
@@ -146,6 +146,44 @@ local function _onPlayerRemoving(player)
 	print(string.format("[SessionManager] %s left — data cleaned up", player.Name))
 end
 
+-- ─── Per-round reset ──────────────────────────────────────────────────────────
+-- Destroy spawned vehicles and clear per-round state when a new cycle begins.
+-- Without this, the previous race's vehicle persisted in workspace and the
+-- player stayed seated in it (BodyAngularVelocity / SuspensionHover kept the
+-- chassis spinning in mid-air) when the FARMING phase of the next round
+-- started, so players showed up in the new farm area still glued to the old
+-- car.
+
+local function _resetForNewRound()
+	for _, data in pairs(PlayerData) do
+		if data.vehicleModel and data.vehicleModel.Parent then
+			data.vehicleModel:Destroy()
+		end
+		data.vehicleModel       = nil
+		data.vehicleStats       = nil
+		data.inventory          = {}
+		data.raceProgress       = 0
+		data.raceRank           = 0
+		data.finishTime         = nil
+		data.stealCooldownEnd   = 0
+		data.stealInvincibleEnd = 0
+	end
+
+	-- LoadCharacter respawns at SpawnLocation. Required because destroying the
+	-- VehicleSeat alone leaves the humanoid stranded mid-air where the seat
+	-- used to be (SKY especially — vehicle hovers at Y≈80 with no ground
+	-- beneath the player).
+	for _, player in ipairs(Players:GetPlayers()) do
+		pcall(function() player:LoadCharacter() end)
+	end
+end
+
+GameManager.onPhaseChanged(function(phase)
+	if phase == Constants.PHASES.LOBBY then
+		_resetForNewRound()
+	end
+end)
+
 -- ─── Wire up ──────────────────────────────────────────────────────────────────
 
 Players.PlayerAdded:Connect(_onPlayerAdded)


### PR DESCRIPTION
## Summary
- Image #6 버그: 라운드 종료 후 다음 라운드 FARMING이 시작돼도 이전 vehicle이 workspace에 남아 있고 플레이어가 그 위에 앉은 채로 공중에서 회전 (SKY에서 특히 명확).
- 원인: \`_startResults\` → 30s → \`_startLobby\` → \`_startFarming\` 흐름 어디에서도 \`vehicleModel:Destroy()\`를 호출하지 않음. \`SessionManager\`는 \`PlayerRemoving\`에서만 청소.
- 수정: \`SessionManager\`에 LOBBY 진입 phase listener 추가. \`vehicleModel\` 파괴 + 라운드별 PlayerData(\`vehicleStats\`, \`inventory\`, \`raceProgress\`…) 리셋 + 모든 플레이어 \`LoadCharacter()\`로 SpawnLocation 재스폰.
- VehicleSeat만 파괴하면 humanoid가 공중에 매달리니까 (특히 SKY는 발 밑에 지면이 없음) LoadCharacter 필수.

## Test plan
- [ ] Studio 솔로 모드 → 한 바퀴 완주 → RESULTS 30s 대기 → 자동으로 새 라운드 시작 시 vehicle 사라지고 SpawnLocation에서 시작하는지 확인.
- [ ] SKY biome 한 번, FOREST 한 번 각각 확인.
- [ ] 라운드 첫 시작 (boot)에는 PlayerData가 비어 있어 noop인지 확인 (regression 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)