### PR TITLE
fix(#125): inventory icons blank for Lantern/Barrel/Life Preserver

### DIFF
--- a/roblox/ReplicatedStorage/Shared/ItemConfig.lua
+++ b/roblox/ReplicatedStorage/Shared/ItemConfig.lua
@@ -22,7 +22,7 @@ ItemConfig["Barrel"] = {
 	rarity         = R.COMMON,
 	weight         = 3,
 	grip           = 0.35,
-	icon           = "🪣",
+	icon           = "🛢️",
 	shape          = "barrel",
 	mobilityAffinity = {},
 }
@@ -85,7 +85,7 @@ ItemConfig["Life Preserver"] = {
 	weight         = 4,
 	grip           = 0.45,
 	floatabilityBonus = 2.0,   -- doubles floatability in OCEAN
-	icon           = "🛟",
+	icon           = "⚓",
 	shape          = "lifepreserver",
 	biomeBonus     = { OCEAN = 1.20 },
 	mobilityAffinity = { OCEAN = true },
@@ -328,7 +328,7 @@ ItemConfig["Lantern"] = {
 	slotType   = "SPECIAL",
 	rarity     = R.COMMON,
 	boost      = 15,
-	icon       = "🏮",
+	icon       = "💡",
 	shape      = "lantern",
 }
 


### PR DESCRIPTION
Closes #125.

## Summary
- GothamBold이 일부 emoji codepoint를 렌더링하지 못해서 인벤토리 UI에 빈 박스/빨간 사각형으로 나오던 3개 아이템 아이콘 교체.
- Barrel 🪣 → 🛢️
- Life Preserver 🛟 → ⚓
- Lantern 🏮 → 💡

이슈에 제안된 1번 안 (older codepoint로 swap) 따름. 더 견고한 ImageLabel 기반 아이콘은 후속 자산 정리 PR에서.

## Test plan
- [ ] Studio 솔로 → 파밍 phase에서 Barrel, Life Preserver, Lantern 픽업 → 인벤토리 슬롯에 새 아이콘이 보이는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)