### PR TITLE
fix: 11 more blank inventory icons (Magic Wand, Drill, Kettle, ...)

### DIFF
--- a/roblox/ReplicatedStorage/Shared/ItemConfig.lua
+++ b/roblox/ReplicatedStorage/Shared/ItemConfig.lua
@@ -53,7 +53,7 @@ ItemConfig["Skateboard"] = {
 	rarity         = R.UNCOMMON,
 	weight         = 3,
 	grip           = 0.25,
-	icon           = "🛹",
+	icon           = "⛸️",
 	shape          = "skateboard",
 	mobilityAffinity = { FOREST = true },
 }
@@ -63,7 +63,7 @@ ItemConfig["Log"] = {
 	rarity         = R.UNCOMMON,
 	weight         = 10,
 	grip           = 0.70,
-	icon           = "🪵",
+	icon           = "🌲",
 	shape          = "log",
 	biomeBonus     = { FOREST = 1.10 },
 	mobilityAffinity = { FOREST = true },
@@ -97,7 +97,7 @@ ItemConfig["Kite"] = {
 	weight         = 2,
 	grip           = 0.10,
 	flyabilityBonus = 2.5,     -- 2.5× flyability in SKY
-	icon           = "🪁",
+	icon           = "🎐",
 	shape          = "kite",
 	biomeBonus     = { SKY = 1.20 },
 	mobilityAffinity = { SKY = true },
@@ -110,7 +110,7 @@ ItemConfig["Suitcase"] = {
 	rarity         = R.RARE,
 	weight         = 9,
 	grip           = 0.60,
-	icon           = "🧳",
+	icon           = "💼",
 	shape          = "suitcase",
 	mobilityAffinity = {},
 }
@@ -140,7 +140,7 @@ ItemConfig["Microwave"] = {
 	rarity         = R.EPIC,
 	weight         = 15,
 	grip           = 0.90,
-	icon           = "🧊",
+	icon           = "📺",
 	shape          = "microwave",
 	mobilityAffinity = {},
 }
@@ -211,7 +211,7 @@ ItemConfig["Compass"] = {
 	slotType   = "ENGINE",
 	rarity     = R.RARE,
 	power      = 22,
-	icon       = "🧭",
+	icon       = "➡️",
 	shape      = "compass",
 }
 
@@ -236,7 +236,7 @@ ItemConfig["Drill"] = {
 	slotType   = "ENGINE",
 	rarity     = R.RARE,
 	power      = 22,
-	icon       = "🪛",
+	icon       = "🔧",
 	shape      = "drill",
 	biomeBonus = { FOREST = 1.25 },
 }
@@ -261,7 +261,7 @@ ItemConfig["Kettle"] = {
 	slotType   = "ENGINE",
 	rarity     = R.EPIC,
 	power      = 40,
-	icon       = "🫖",
+	icon       = "☕",
 	shape      = "kettle",
 }
 
@@ -296,7 +296,7 @@ ItemConfig["Toilet Paper"] = {
 	slotType   = "SPECIAL",
 	rarity     = R.COMMON,
 	boost      = 20,
-	icon       = "🧻",
+	icon       = "📜",
 	shape      = "roll",
 }
 
@@ -312,7 +312,7 @@ ItemConfig["Magnet"] = {
 	slotType   = "SPECIAL",
 	rarity     = R.UNCOMMON,
 	boost      = 30,
-	icon       = "🧲",
+	icon       = "📎",
 	shape      = "magnet",
 }
 
@@ -344,7 +344,7 @@ ItemConfig["Magic Wand"] = {
 	slotType   = "SPECIAL",
 	rarity     = R.RARE,
 	boost      = 45,
-	icon       = "🪄",
+	icon       = "✨",
 	shape      = "wand",
 }
 


### PR DESCRIPTION
## Summary
- Magic Wand 🪄 (U+1FA84, Unicode 13) reported blank in inventory UI — same root cause as #125.
- Audited remaining icons by codepoint vintage; 11 items use Unicode 11+ (2018+) emojis that GothamBold can't render reliably.
- Swapped each to a pre-Unicode-9 (2016 or earlier) analog.

## Swaps
| Item | Before | After | Reason |
|---|---|---|---|
| Skateboard | 🛹 | ⛸️ | U11 → U6 (skate analog) |
| Log | 🪵 | 🌲 | U13 → U6 (forest theme preserved) |
| Kite | 🪁 | 🎐 | U12 → U6 (wind-themed) |
| Suitcase | 🧳 | 💼 | U11 → U6 (briefcase) |
| Microwave | 🧊 | 📺 | U11 → U6 (also: 🧊 was an ice cube, not a microwave) |
| Compass | 🧭 | ➡️ | U11 → U6 (direction) |
| Drill | 🪛 | 🔧 | U13 → U6 (tool) |
| Kettle | 🫖 | ☕ | U13 → U4.1 (hot beverage) |
| Toilet Paper | 🧻 | 📜 | U11 → U6 (rolled paper) |
| Magnet | 🧲 | 📎 | U11 → U6 (attraction metaphor) |
| Magic Wand | 🪄 | ✨ | U13 → U6 (sparkles) |

Long-term fix tracked in #125 §해결 방향 2: replace `icon` string with ImageLabel + Roblox asset ID.

## Test plan
- [ ] Open inventory UI in Studio; confirm each of the 11 items renders a visible glyph (not white box / blank).
- [ ] Compare against previously confirmed-working items (Pizza 🍕, Rocket 🚀, Cactus 🌵) — glyph should look comparable.
- [ ] No code paths read icon values for logic (only display), so functional regression risk is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)