### PR TITLE
feat(#139): BODY-dominant vehicle silhouette

### DIFF
--- a/roblox/ReplicatedStorage/Shared/SlotMountConfig.lua
+++ b/roblox/ReplicatedStorage/Shared/SlotMountConfig.lua
@@ -20,41 +20,46 @@ local SlotMountConfig = {}
 --   OCEAN  anchor sits at hull center, +Z forward.
 --   SKY    anchor sits at fuselage center, -Z is forward (legacy buildFlyer convention).
 
+-- Sizing strategy: BODY dominates (~4–5 studs, sits prominently above the
+-- procedural chassis), MOBILITY scales to its biome role (wheels, sail, wings),
+-- and ENGINE/SPECIAL/HEAD/TAIL stay small (~1.2–1.8 studs) so the chassis
+-- silhouette remains readable. Tuned so picking different slot items produces
+-- visibly different vehicles without obscuring the base shape.
 SlotMountConfig.MOUNTS = {
 	BODY = {
-		FOREST = { scale = 7.0, offset = V3(0,  0.6, 0), rot = V3(0, 0, 0), pattern = "chassis" },
-		OCEAN  = { scale = 8.0, offset = V3(0,  0.4, 0), rot = V3(0, 0, 0), pattern = "chassis" },
-		SKY    = { scale = 7.5, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+		FOREST = { scale = 4.5, offset = V3(0,  0.6, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+		OCEAN  = { scale = 5.5, offset = V3(0,  0.4, 0), rot = V3(0, 0, 0), pattern = "chassis" },
+		SKY    = { scale = 5.0, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0), pattern = "chassis" },
 	},
 
 	MOBILITY = {
 		FOREST = { scale = 1.6, offset = V3(0, -0.6, 0), rot = V3(0, 0, 90), pattern = "wheels4" },
-		OCEAN  = { scale = 3.5, offset = V3(0,  2.0, 0), rot = V3(0, 0, 0),  pattern = "sail" },
-		SKY    = { scale = 3.0, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0),  pattern = "wings2" },
+		OCEAN  = { scale = 2.5, offset = V3(0,  2.0, 0), rot = V3(0, 0, 0),  pattern = "sail" },
+		SKY    = { scale = 2.0, offset = V3(0,  0.0, 0), rot = V3(0, 0, 0),  pattern = "wings2" },
 	},
 
 	ENGINE = {
-		FOREST = { scale = 2.0, offset = V3(0,  0.8, -2.5), rot = V3(0, 0, 0), pattern = "single" },
-		OCEAN  = { scale = 2.0, offset = V3(0,  1.0, -3.0), rot = V3(0, 0, 0), pattern = "single" },
-		SKY    = { scale = 1.8, offset = V3(0,  0.0,  2.5), rot = V3(0, 0, 0), pattern = "single" },
+		FOREST = { scale = 1.5, offset = V3(0,  0.8, -2.5), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.5, offset = V3(0,  1.0, -3.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.3, offset = V3(0,  0.0,  2.5), rot = V3(0, 0, 0), pattern = "single" },
 	},
 
 	SPECIAL = {
-		FOREST = { scale = 2.0, offset = V3(0,  2.0,  0.5), rot = V3(0, 0, 0), pattern = "single" },
-		OCEAN  = { scale = 2.0, offset = V3(0,  3.5,  0.5), rot = V3(0, 0, 0), pattern = "single" },
-		SKY    = { scale = 1.8, offset = V3(0,  1.0,  0.0), rot = V3(0, 0, 0), pattern = "single" },
+		FOREST = { scale = 1.8, offset = V3(0,  2.0,  0.5), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.8, offset = V3(0,  3.5,  0.5), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.5, offset = V3(0,  1.0,  0.0), rot = V3(0, 0, 0), pattern = "single" },
 	},
 
 	HEAD = {
-		FOREST = { scale = 1.8, offset = V3(0,  1.2,  3.0), rot = V3(0, 0, 0), pattern = "single" },
-		OCEAN  = { scale = 1.8, offset = V3(0,  1.2,  4.0), rot = V3(0, 0, 0), pattern = "single" },
-		SKY    = { scale = 1.8, offset = V3(0,  0.4, -4.0), rot = V3(0, 0, 0), pattern = "single" },
+		FOREST = { scale = 1.2, offset = V3(0,  1.2,  3.0), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.2, offset = V3(0,  1.2,  4.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.2, offset = V3(0,  0.4, -4.0), rot = V3(0, 0, 0), pattern = "single" },
 	},
 
 	TAIL = {
-		FOREST = { scale = 1.8, offset = V3(0,  1.2, -3.0), rot = V3(0, 0, 0), pattern = "single" },
-		OCEAN  = { scale = 1.8, offset = V3(0,  1.2, -4.0), rot = V3(0, 0, 0), pattern = "single" },
-		SKY    = { scale = 1.8, offset = V3(0,  0.4,  3.0), rot = V3(0, 0, 0), pattern = "single" },
+		FOREST = { scale = 1.2, offset = V3(0,  1.2, -3.0), rot = V3(0, 0, 0), pattern = "single" },
+		OCEAN  = { scale = 1.2, offset = V3(0,  1.2, -4.0), rot = V3(0, 0, 0), pattern = "single" },
+		SKY    = { scale = 1.2, offset = V3(0,  0.4,  3.0), rot = V3(0, 0, 0), pattern = "single" },
 	},
 }
 

--- a/roblox/ServerScriptService/Modules/VehicleBuilder.lua
+++ b/roblox/ServerScriptService/Modules/VehicleBuilder.lua
@@ -6,9 +6,10 @@
 
 local ServerStorage = game:GetService("ServerStorage")
 
-local Constants  = require(game.ReplicatedStorage.Shared.Constants)
-local ItemConfig = require(game.ServerScriptService.Modules.ItemConfig)
-local VehicleStats = require(game.ReplicatedStorage.Shared.VehicleStats)
+local Constants       = require(game.ReplicatedStorage.Shared.Constants)
+local ItemConfig      = require(game.ServerScriptService.Modules.ItemConfig)
+local VehicleStats    = require(game.ReplicatedStorage.Shared.VehicleStats)
+local SlotMountConfig = require(game.ReplicatedStorage.Shared.SlotMountConfig)
 
 local VehicleBuilder = {}
 
@@ -75,8 +76,12 @@ local function weld(part0, part1)
 end
 
 -- ─── Item visual (coloured block representing the item) ───────────────────────
+-- targetScale: longest-axis size in studs the clone should fit into. Required so
+--              BODY items dominate (~6–8 studs) while HEAD/TAIL/SPECIAL/ENGINE
+--              ride small (~1.5–2 studs) and don't visually overwhelm the chassis.
+-- rotDeg     : optional Vector3 of Euler angles (degrees) applied to the clone.
 
-local function itemVisual(itemName, attachCF, model)
+local function itemVisual(itemName, attachCF, model, targetScale, rotDeg)
 	local cfg  = ItemConfig[itemName]
 	if not cfg then return end
 
@@ -89,10 +94,54 @@ local function itemVisual(itemName, attachCF, model)
 	local tmpl      = templates and templates:FindFirstChild(itemName)
 	if tmpl and tmpl.PrimaryPart then
 		local clone = tmpl:Clone()
+		local primary = clone.PrimaryPart
+
+		-- Bbox-normalize before placement. Preloader normalizes to ~4 studs,
+		-- but per-slot targets differ (BODY huge, HEAD/TAIL small). Compute
+		-- current extent from BaseParts and scale all part sizes + positions
+		-- around the primary's center.
+		if targetScale and targetScale > 0 then
+			local minV, maxV
+			for _, p in ipairs(clone:GetDescendants()) do
+				if p:IsA("BasePart") then
+					local half = p.Size * 0.5
+					local lo, hi = p.Position - half, p.Position + half
+					minV = minV and Vector3.new(math.min(minV.X, lo.X), math.min(minV.Y, lo.Y), math.min(minV.Z, lo.Z)) or lo
+					maxV = maxV and Vector3.new(math.max(maxV.X, hi.X), math.max(maxV.Y, hi.Y), math.max(maxV.Z, hi.Z)) or hi
+				end
+			end
+			if minV and maxV then
+				local extent = maxV - minV
+				local longest = math.max(extent.X, extent.Y, extent.Z)
+				if longest > 0 then
+					local factor = targetScale / longest
+					if math.abs(factor - 1) > 0.01 then
+						local center = primary.Position
+						for _, p in ipairs(clone:GetDescendants()) do
+							if p:IsA("BasePart") then
+								p.Size     = p.Size * factor
+								p.Position = center + (p.Position - center) * factor
+							end
+						end
+					end
+				end
+			end
+		end
+
+		-- Optional rotation about the primary's current position.
+		local rotCF = CFrame.new()
+		if rotDeg and (rotDeg.X ~= 0 or rotDeg.Y ~= 0 or rotDeg.Z ~= 0) then
+			rotCF = CFrame.Angles(
+				math.rad(rotDeg.X),
+				math.rad(rotDeg.Y),
+				math.rad(rotDeg.Z)
+			)
+		end
+
 		-- Manual delta translation — SetPrimaryPartCFrame/PivotTo don't move
 		-- FBX-imported nested parts in this codebase's mesh structure.
-		local primary = clone.PrimaryPart
-		local delta   = attachCF * primary.CFrame:Inverse()
+		local targetCF = attachCF * rotCF
+		local delta    = targetCF * primary.CFrame:Inverse()
 		for _, p in ipairs(clone:GetDescendants()) do
 			if p:IsA("BasePart") then
 				p.CFrame     = delta * p.CFrame
@@ -395,7 +444,7 @@ end
 
 -- ─── Attach item visuals ──────────────────────────────────────────────────────
 
-local function _attachItems(model, primaryPart, slots)
+local function _attachItems(model, primaryPart, slots, biome)
 	local mountNames = {
 		BODY     = "BodyMount",
 		ENGINE   = "EngineMount",
@@ -412,8 +461,14 @@ local function _attachItems(model, primaryPart, slots)
 		local att = primaryPart:FindFirstChild(mountName)
 		if not att then continue end
 
+		-- Per-slot/per-biome scale + rotation (silhouette: BODY dominates,
+		-- HEAD/TAIL/ENGINE/SPECIAL stay small so chassis remains readable).
+		local mount = SlotMountConfig.get(slotName, biome)
+		local scale = mount and mount.scale
+		local rot   = mount and mount.rot
+
 		local worldCF = primaryPart.CFrame * att.CFrame
-		local visPart = itemVisual(itemName, worldCF, model)
+		local visPart = itemVisual(itemName, worldCF, model, scale, rot)
 		if visPart then
 			weld(primaryPart, visPart)
 		end
@@ -489,7 +544,7 @@ function VehicleBuilder.build(stats, biome, spawnCFrame, slots)
 	end
 
 	-- Attach item visuals at mount points
-	_attachItems(model, primaryPart, slots)
+	_attachItems(model, primaryPart, slots, biome)
 
 	-- Visual flair from stats
 	_applyStatVisuals(model, stats, palette)


### PR DESCRIPTION
## Summary
- Crafted vehicles barely reflected slot choices — every item rendered at the preloader's ~4-stud normalized size, so chassis dominated and HEAD/TAIL/SPECIAL items all looked identical regardless of pick.
- Wires `SlotMountConfig.get(slot, biome).scale` + `.rot` into `VehicleBuilder.itemVisual` so each slot gets a different target size per biome.
- Approach: **additive** ("BODY big, others small") — keeps procedural chassis intact rather than replacing it. Picking a Microwave or Bathtub for BODY now visibly dominates the silhouette while small decoration items don't swallow the whole vehicle.

## Sizing
| Slot     | FOREST | OCEAN | SKY  |
|----------|--------|-------|------|
| BODY     | 4.5    | 5.5   | 5.0  |
| MOBILITY | 1.6    | 2.5   | 2.0  |
| ENGINE   | 1.5    | 1.5   | 1.3  |
| SPECIAL  | 1.8    | 1.8   | 1.5  |
| HEAD     | 1.2    | 1.2   | 1.2  |
| TAIL     | 1.2    | 1.2   | 1.2  |

## How it works
`itemVisual(itemName, attachCF, model, targetScale, rotDeg)`:
1. Walk BaseParts → compute bbox extent.
2. `factor = targetScale / max(extent.X, extent.Y, extent.Z)`.
3. Scale every part's `Size *= factor` and `Position = center + (Position - center) * factor`.
4. Optional Euler rotation about PrimaryPart center.
5. Existing delta-CFrame placement at the mount attachment.

Mass + collision contract unchanged: all clones stay `Massless` and `CanCollide=false` so drive (BodyVelocity along PrimaryPart LookVector) is stable.

## Out of scope
- **Suppress-procedural-when-filled** (don't render procedural wheels/sail/wings when MOBILITY is filled). Plan §PR-C — can land separately if playtest shows duplicates.
- **BODY-as-chassis** (item mesh literally replaces procedural box). Plan §PR-B — more ambitious; skipped here to keep risk low.

## Test plan
- [ ] FOREST: craft with different BODY items (Skateboard, Log, Microwave, Bathtub) → silhouette visibly differs.
- [ ] OCEAN: BODY=Bamboo Raft vs Backpack → boats look different.
- [ ] SKY: BODY=Kite vs Suitcase → flyers look different.
- [ ] HEAD/TAIL filled → small extension at front/back, doesn't dominate.
- [ ] Drive feel unchanged across all 3 biomes (forward = LookVector, steer responsive).
- [ ] VehicleSeat:Sit works; player not clipping into item meshes.
- [ ] No-slot fallback (empty inventory) still produces drivable procedural chassis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)