### PR TITLE
recover: bring FOREST/OCEAN/CheckpointUI to main

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -1,10 +1,11 @@
 -- ForestMapBuilder.server.lua
--- Procedurally builds the FOREST biome map:
---   - Farm area with crop rows and barn silhouette
---   - S-curve race track (alternating left/right offsets via node-based layout)
---   - River-crossing bridge section, rock pile obstacles, mud zones
---   - 3 distinct tree species (pine, oak, birch) for visual variety
--- Resolves: Issue #8, #83, #66, #87, #97
+-- Procedurally builds the FOREST biome map per racetrack spec §2:
+--   - 4700-stud centerline (figure-3 + U-bend) along Z = +600 → -2000
+--   - 40-wide corridor with continuous 8-stud-tall walls both sides
+--   - Bridge crosses S3 sweeper; rock outcrops/mud relocated OUTSIDE walls
+--   - CP1 inside S3 sweeper, CP2 inside S4 U-bend (#126 CheckpointService)
+--   - Ramps + boost pads as thin floor-only (no side collision on props)
+-- Resolves: Issue #8, #83, #66, #87, #97, #128
 
 local CollectionService = game:GetService("CollectionService")
 
@@ -20,7 +21,8 @@ local C = {
 	ROCK_DARK    = Color3.fromRGB(80,  72,  65),
 	BOOST_PAD    = Color3.fromRGB(255, 200, 40),
 	RAMP         = Color3.fromRGB(150, 125, 80),
-	BARRIER      = Color3.fromRGB(200, 60,  40),
+	WALL         = Color3.fromRGB(95,  68,  42),
+	WALL_TOP     = Color3.fromRGB(200, 60,  40),
 	BARN_WALL    = Color3.fromRGB(165, 55,  40),
 	BARN_ROOF    = Color3.fromRGB(80,  60,  45),
 	CROP_GREEN   = Color3.fromRGB(70,  160, 55),
@@ -48,6 +50,10 @@ local MAT = {
 	ROCK   = Enum.Material.Rock,
 	WATER  = Enum.Material.SmoothPlastic,
 }
+
+local TRACK_W   = 40       -- corridor width (spec §2 table)
+local WALL_H    = 8        -- wall height (spec §2 table; cars hop ramps and clear 5)
+local TRACK_TOP = 1.0      -- Y of track surface (Part top)
 
 local function _part(parent, props)
 	local p = Instance.new("Part")
@@ -84,8 +90,63 @@ local function _getOrCreateMap()
 	return model
 end
 
--- ─── Segment CFrame helper ────────────────────────────────────────────────────
--- Returns a CFrame at the midpoint of A→B oriented so local +Z runs along A→B.
+-- ─── Track node layout (spec §2.1, figure-3 + U-bend) ─────────────────────────
+-- Centerline path ~4500-4700 studs; Z-extent 600 → -2050; net path/Z ratio ~1.8.
+-- Race direction: vehicle starts at N1 (Z=600) and progresses toward Nlast (Z=-2050).
+--
+-- S1 (Starting Straight)         : N1  → N2     (~400)
+-- S2 (Outcrop Hairpin, right 90°): N2  → N8     (~600)
+-- S3 (River Sweeper, left 120°)  : N8  → N15    (~1100), bridge at N10
+-- S4 (Farm U-Bend, 180° around)  : N15 → N23    (~1400)
+-- S5 (Mud S-Chicane + finish)    : N23 → N30    (~1200)
+
+local NODES = {
+	-- S1
+	{   0,   600 }, -- N1  start grid line
+	{   0,   200 }, -- N2  end of S1 / S2 entry
+
+	-- S2 right 90° around rock outcrop
+	{   0,   100 }, -- N3  approach
+	{  20,    60 }, -- N4  arc enter
+	{  60,    30 }, -- N5  arc apex (outcrop sits at +X side, decor only)
+	{ 120,    20 }, -- N6  arc exit
+	{ 300,    20 }, -- N7  departure straight
+	{ 450,     0 }, -- N8  end of S2
+
+	-- S3 long left 120° sweeper, bridge at N10
+	{ 550,  -120 }, -- N9
+	{ 580,  -300 }, -- N10 bridge crosses centerline here
+	{ 550,  -480 }, -- N11
+	{ 460,  -640 }, -- N12
+	{ 310,  -750 }, -- N13
+	{ 130,  -820 }, -- N14 CP1 zone
+	{ -50,  -830 }, -- N15 end of S3
+
+	-- S4 U-bend around farm island (peak at N19)
+	{ -220, -870  }, -- N16
+	{ -360, -970  }, -- N17
+	{ -450, -1130 }, -- N18
+	{ -470, -1310 }, -- N19 U peak (CP2 zone)
+	{ -420, -1450 }, -- N20
+	{ -280, -1530 }, -- N21
+	{ -100, -1530 }, -- N22
+	{   50, -1500 }, -- N23 end of S4
+
+	-- S5 S-chicane (right→left), then 230-stud finish straight at X=0
+	{  180, -1550 }, -- N24 chicane right curve
+	{  130, -1620 }, -- N25 return
+	{    0, -1640 }, -- N26 crossover
+	{ -100, -1670 }, -- N27 chicane left peak
+	{  -30, -1740 }, -- N28 return
+	{    0, -1770 }, -- N29 onto finish straight (X=0 from here)
+	{    0, -2000 }, -- N30 FinishLine sensor at Z=-2000 (Constants.TRACK.FOREST.zFinish)
+	{    0, -2050 }, -- N31 runoff past finish
+}
+
+-- Finish-line Z (FinishLine sensor / arch). Must match Constants.TRACK.FOREST.zFinish (-2000 ± approach).
+local FINISH_Z = -2000
+
+-- ─── Segment helpers ──────────────────────────────────────────────────────────
 
 local function _segCF(ax, az, bx, bz)
 	local mx, mz = (ax + bx) * 0.5, (az + bz) * 0.5
@@ -101,156 +162,115 @@ end
 -- ─── Ground plane ─────────────────────────────────────────────────────────────
 
 local function _buildGround(root)
+	-- Large grass plane covering full track bbox plus generous margin.
 	_part(root, {
 		Name     = "Ground",
-		Size     = Vector3.new(400, 4, 1500),
-		Position = Vector3.new(0, -2, 0),
+		Size     = Vector3.new(1400, 4, 3200),
+		Position = Vector3.new(0, -2, -700),
 		Color    = C.GRASS,
 		Material = MAT.GRASS,
 	})
-	-- Darker undergrowth strips for texture
+
 	local rng = Random.new(77)
-	for _ = 1, 30 do
+	for _ = 1, 60 do
 		_part(root, {
-			Name         = "GrassDetail",
-			Size         = Vector3.new(rng:NextNumber(12,35), 0.3, rng:NextNumber(8,22)),
-			Position     = Vector3.new(rng:NextNumber(-180,180), 0.2, rng:NextNumber(-600,600)),
-			Color        = Color3.fromRGB(55, 100, 38),
-			Material     = MAT.GRASS,
-			CanCollide   = false,
-			CastShadow   = false,
+			Name       = "GrassDetail",
+			Size       = Vector3.new(rng:NextNumber(15, 40), 0.3, rng:NextNumber(10, 25)),
+			Position   = Vector3.new(rng:NextNumber(-600, 600), 0.2, rng:NextNumber(-2100, 700)),
+			Color      = Color3.fromRGB(55, 100, 38),
+			Material   = MAT.GRASS,
+			CanCollide = false,
+			CastShadow = false,
 		})
 	end
 end
 
--- ─── Farm area (Z = 200 to 500) ───────────────────────────────────────────────
+-- ─── Farm area (used only during FARMING phase; hidden during RACING) ─────────
+-- Relocated behind the start grid (Z=700–1000) so its props never sit inside
+-- the racing corridor.
+
+local FARM_CX, FARM_CZ = 0, 850
 
 local function _buildFarmArea(root)
-	-- Dirt base
 	_part(root, {
 		Name     = "FarmGround",
-		Size     = Vector3.new(200, 2, 300),
-		Position = Vector3.new(0, 0, 350),
+		Size     = Vector3.new(220, 2, 320),
+		Position = Vector3.new(FARM_CX, 0, FARM_CZ),
 		Color    = C.DIRT,
 		Material = MAT.DIRT,
 	})
 
-	-- Crop rows: thin green strips in a grid
-	for row = 0, 6 do
+	for row = 0, 7 do
 		for col = -3, 3 do
 			_part(root, {
-				Name         = "CropRow",
-				Size         = Vector3.new(18, 1.5, 3),
-				Position     = Vector3.new(col * 22, 0.8, 280 + row * 30),
-				Color        = C.CROP_GREEN,
-				Material     = MAT.LEAVES,
-				CanCollide   = false,
-				CastShadow   = false,
+				Name       = "CropRow",
+				Size       = Vector3.new(18, 1.5, 3),
+				Position   = Vector3.new(FARM_CX + col * 22, 0.8, FARM_CZ - 100 + row * 30),
+				Color      = C.CROP_GREEN,
+				Material   = MAT.LEAVES,
+				CanCollide = false,
+				CastShadow = false,
 			})
 		end
 	end
 
-	-- Barn silhouette (left side of farm)
-	_part(root, {  -- barn walls
+	_part(root, {
 		Name     = "BarnWall",
 		Size     = Vector3.new(25, 14, 18),
-		Position = Vector3.new(-75, 7, 360),
+		Position = Vector3.new(FARM_CX - 80, 7, FARM_CZ),
 		Color    = C.BARN_WALL,
 		Material = MAT.WOOD,
 	})
-	local barnRoof = _wedge(root, {  -- barn roof left slope
-		Name     = "BarnRoof",
-		Size     = Vector3.new(12, 8, 18),
-		Position = Vector3.new(-81, 18, 360),
-		Color    = C.BARN_ROOF,
-		Material = MAT.WOOD,
-		CanCollide = false,
+	local r1 = _wedge(root, {
+		Name = "BarnRoof", Size = Vector3.new(12, 8, 18),
+		Color = C.BARN_ROOF, Material = MAT.WOOD, CanCollide = false,
 	})
-	barnRoof.CFrame = CFrame.new(-81, 18, 360) * CFrame.Angles(0, math.pi/2, 0)
-	local barnRoof2 = _wedge(root, {  -- barn roof right slope
-		Name     = "BarnRoof2",
-		Size     = Vector3.new(12, 8, 18),
-		Position = Vector3.new(-69, 18, 360),
-		Color    = C.BARN_ROOF,
-		Material = MAT.WOOD,
-		CanCollide = false,
+	r1.CFrame = CFrame.new(FARM_CX - 86, 18, FARM_CZ) * CFrame.Angles(0,  math.pi/2, 0)
+	local r2 = _wedge(root, {
+		Name = "BarnRoof2", Size = Vector3.new(12, 8, 18),
+		Color = C.BARN_ROOF, Material = MAT.WOOD, CanCollide = false,
 	})
-	barnRoof2.CFrame = CFrame.new(-69, 18, 360) * CFrame.Angles(0, -math.pi/2, 0)
-	-- Barn door
-	_part(root, {
-		Name     = "BarnDoor",
-		Size     = Vector3.new(8, 10, 0.5),
-		Position = Vector3.new(-75, 5, 351),
-		Color    = C.BARN_ROOF,
-		Material = MAT.WOOD,
-		CanCollide = false,
-	})
+	r2.CFrame = CFrame.new(FARM_CX - 74, 18, FARM_CZ) * CFrame.Angles(0, -math.pi/2, 0)
 
-	-- Fence boundary
+	-- Fence boundary (cosmetic; CanCollide false)
 	local fences = {
-		{ Vector3.new(202, 5, 1.5), Vector3.new(0,   2.5, 200) },
-		{ Vector3.new(202, 5, 1.5), Vector3.new(0,   2.5, 500) },
-		{ Vector3.new(1.5, 5, 302), Vector3.new(-101, 2.5, 350) },
-		{ Vector3.new(1.5, 5, 302), Vector3.new( 101, 2.5, 350) },
+		{ Vector3.new(222, 5, 1.5), Vector3.new(FARM_CX,     2.5, FARM_CZ - 160) },
+		{ Vector3.new(222, 5, 1.5), Vector3.new(FARM_CX,     2.5, FARM_CZ + 160) },
+		{ Vector3.new(1.5, 5, 322), Vector3.new(FARM_CX - 111, 2.5, FARM_CZ) },
+		{ Vector3.new(1.5, 5, 322), Vector3.new(FARM_CX + 111, 2.5, FARM_CZ) },
 	}
 	for _, fd in ipairs(fences) do
 		local f = _part(root, { Name="Fence", Size=fd[1], Position=fd[2], Color=C.FENCE, Material=MAT.WOOD })
 		f.CanCollide   = false
 		f.Transparency = 0.2
-		-- Fence post caps
 	end
-
-	-- Fence posts (along near edge only for performance)
 	for px = -100, 100, 20 do
 		_part(root, {
-			Name     = "FencePost",
-			Size     = Vector3.new(1.5, 7, 1.5),
-			Position = Vector3.new(px, 3.5, 200),
-			Color    = C.FENCE,
-			Material = MAT.WOOD,
+			Name = "FencePost", Size = Vector3.new(1.5, 7, 1.5),
+			Position = Vector3.new(FARM_CX + px, 3.5, FARM_CZ - 160),
+			Color = C.FENCE, Material = MAT.WOOD,
 		})
 	end
 
-	-- Spawn points
+	-- FarmSpawn tags (item-spawn anchor points). Spread across crop rows.
 	local cols = { -80, -40, 0, 40, 80 }
-	local rows = { 280, 320 }
-	for _, row in ipairs(rows) do
-		for _, col in ipairs(cols) do
+	local rows = { FARM_CZ - 60, FARM_CZ + 20 }
+	for _, rz in ipairs(rows) do
+		for _, cx in ipairs(cols) do
 			local sp = _part(root, {
-				Name         = "FarmSpawnPoint",
-				Size         = Vector3.new(4, 0.5, 4),
-				Position     = Vector3.new(col, 1.5, row),
-				Color        = Color3.fromRGB(255, 220, 60),
-				Material     = MAT.NEON,
-				CanCollide   = false,
-				CastShadow   = false,
-				Transparency = 0.5,
+				Name = "FarmSpawnPoint", Size = Vector3.new(4, 0.5, 4),
+				Position = Vector3.new(FARM_CX + cx, 1.5, rz),
+				Color = Color3.fromRGB(255, 220, 60), Material = MAT.NEON,
+				CanCollide = false, CastShadow = false, Transparency = 0.5,
 			})
 			_tag(sp, "FarmSpawn")
 		end
 	end
 end
 
--- ─── S-curve race track ───────────────────────────────────────────────────────
--- Node layout (X, Z) defines the track centerline.
--- Travel direction: decreasing Z (farm → finish).
---
---  (0,175) → (-22,45) → (-22,-65) → (20,-185) → (20,-305) → (-18,-415) → (-18,-510) → (0,-575)
---
--- This creates two full S-curves along the 750-stud stretch.
-
-local TRACK_W = 30
-
-local NODES = {
-	{  0,   215 },  -- [1] pre-start straight (covers spawn area Z=195–203)
-	{ -22,   45 },  -- [2] first curve, shifts left
-	{ -22,  -65 },  -- [3] left straight
-	{  20, -185 },  -- [4] S-curve, swings right
-	{  20, -305 },  -- [5] right straight
-	{ -18, -415 },  -- [6] second S-curve, swings left
-	{ -18, -510 },  -- [7] left straight
-	{   0, -605 },  -- [8] finish approach (extends past finish line at Z=-599)
-}
+-- ─── Track surface ────────────────────────────────────────────────────────────
+-- One TrackSeg per node-pair, slightly elongated by +2 studs on each end so
+-- adjacent segments overlap at the joints (no thin gap visible at corners).
 
 local function _buildTrack(root)
 	for i = 1, #NODES - 1 do
@@ -260,39 +280,29 @@ local function _buildTrack(root)
 
 		local seg = _part(root, {
 			Name     = "TrackSeg_" .. i,
-			Size     = Vector3.new(TRACK_W, 1, segLen),
+			Size     = Vector3.new(TRACK_W, 1, segLen + 4),
 			Color    = C.TRACK,
 			Material = MAT.TRACK,
 		})
 		seg.CFrame = cf
 
-		-- White edge lines + invisible boundary walls
+		-- White outer-edge stripe (visual only).
 		for _, side in ipairs({ -1, 1 }) do
 			local edge = _part(root, {
-				Name     = "TrackEdge",
-				Size     = Vector3.new(1.5, 1.1, segLen),
-				Color    = C.TRACK_EDGE,
-				Material = MAT.METAL,
+				Name       = "TrackEdge",
+				Size       = Vector3.new(1.5, 1.1, segLen + 4),
+				Color      = C.TRACK_EDGE,
+				Material   = MAT.METAL,
 				CanCollide = false,
 				CastShadow = false,
 			})
 			edge.CFrame = cf * CFrame.new(side * (TRACK_W / 2 - 1), 0.05, 0)
-
-			-- Invisible collideable wall at the outer track boundary.
-			-- Prevents vehicles from leaving the lane.
-			local wall = _part(root, {
-				Name         = "TrackBoundary",
-				Size         = Vector3.new(1, 5, segLen),
-				Transparency = 1,
-				CastShadow   = false,
-			})
-			wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 0.5), 2.5, 0)
 		end
 
-		-- Dashed centre line every ~30 studs
-		local dashCount = math.floor(segLen / 30)
+		-- Dashed centre line
+		local dashCount = math.max(1, math.floor(segLen / 30))
 		for d = 0, dashCount - 1 do
-			local dz = -segLen / 2 + (d + 0.5) * (segLen / (dashCount > 0 and dashCount or 1))
+			local dz = -segLen / 2 + (d + 0.5) * (segLen / dashCount)
 			local dash = _part(root, {
 				Name     = "CentreDash",
 				Size     = Vector3.new(1, 1.15, 14),
@@ -306,14 +316,49 @@ local function _buildTrack(root)
 	end
 end
 
--- ─── River crossing (between nodes 3 and 4, Z ≈ -125) ────────────────────────
+-- ─── Continuous track walls (spec §2.4) ───────────────────────────────────────
+-- Each segment gets a wall on each side, extended by +4 studs each end so
+-- adjacent walls overlap. Two-tone (dark wood + red top-stripe) for visibility.
+
+local function _buildWalls(root)
+	for i = 1, #NODES - 1 do
+		local a, b   = NODES[i], NODES[i + 1]
+		local segLen = _segLen(a[1], a[2], b[1], b[2])
+		local cf     = _segCF(a[1], a[2], b[1], b[2])
+
+		for _, side in ipairs({ -1, 1 }) do
+			-- Visible wall body
+			local wall = _part(root, {
+				Name     = "TrackWall",
+				Size     = Vector3.new(2, WALL_H, segLen + 8),
+				Color    = C.WALL,
+				Material = MAT.WOOD,
+			})
+			wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H / 2, 0)
+
+			-- Red top-stripe (collidable but visually distinct)
+			local cap = _part(root, {
+				Name     = "TrackWallCap",
+				Size     = Vector3.new(2.4, 0.6, segLen + 8),
+				Color    = C.WALL_TOP,
+				Material = MAT.NEON,
+			})
+			cap.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H + 0.3, 0)
+			cap.CastShadow = false
+		end
+	end
+end
+
+-- ─── River + bridge across S3 (between N10 and centerline) ───────────────────
 
 local function _buildRiverBridge(root)
-	-- Water channel running east-west (perpendicular to track)
-	local riverZ = -125
-	local waterPart = _part(root, {
+	local riverZ = -300                       -- aligns with N10 mid-sweep
+	local centerX = 580                       -- approx N10 x
+	-- Wide cross-river belt (east-west under the corridor). Track surface
+	-- continues over the water; bridge planks visually overlay.
+	_part(root, {
 		Name         = "RiverWater",
-		Size         = Vector3.new(300, 2, 28),
+		Size         = Vector3.new(1200, 2, 60),
 		Position     = Vector3.new(0, -1, riverZ),
 		Color        = C.RIVER,
 		Material     = MAT.WATER,
@@ -321,413 +366,190 @@ local function _buildRiverBridge(root)
 		CanCollide   = false,
 	})
 
-	-- Riverbank embankments
+	-- Riverbanks (decorative wedges, outside the corridor only)
 	for _, side in ipairs({ -1, 1 }) do
 		_wedge(root, {
 			Name     = "RiverBank",
-			Size     = Vector3.new(300, 3, 10),
-			Position = Vector3.new(0, -0.5, riverZ + side * 19),
+			Size     = Vector3.new(1200, 3, 14),
+			Position = Vector3.new(0, -0.5, riverZ + side * 36),
 			Color    = C.DIRT,
 			Material = MAT.DIRT,
+			CanCollide = false,
 		})
 	end
 
-	-- Wooden bridge decking over the track portion
-	-- The track crosses at approximately X = -1 (midpoint between nodes 3 and 4)
-	for plank = -12, 12, 4 do
+	-- Bridge planks over the corridor segment crossing the river.
+	for plank = -16, 16, 4 do
 		_part(root, {
 			Name     = "BridgePlank",
-			Size     = Vector3.new(4, 1.5, 28),
-			Position = Vector3.new(plank, 0.75, riverZ),
+			Size     = Vector3.new(4, 0.6, 60),
+			Position = Vector3.new(centerX + plank, 1.3, riverZ),
 			Color    = C.BRIDGE,
 			Material = MAT.WOOD,
+			CanCollide = false,
 		})
 	end
 
-	-- Bridge railings
+	-- Bridge railings live OUTSIDE the corridor walls (cosmetic, non-collidable).
 	for _, side in ipairs({ -1, 1 }) do
 		_part(root, {
 			Name     = "BridgeRailing",
-			Size     = Vector3.new(0.6, 3, 30),
-			Position = Vector3.new(side * 15.5, 2, riverZ),
+			Size     = Vector3.new(0.6, 3, 64),
+			Position = Vector3.new(centerX + side * (TRACK_W / 2 + 3), 3, riverZ),
 			Color    = C.BRIDGE,
 			Material = MAT.WOOD,
-			CanCollide = false,
-		})
-		-- Railing posts
-		for pz = -12, 12, 8 do
-			_part(root, {
-				Name     = "BridgePost",
-				Size     = Vector3.new(1.2, 4, 1.2),
-				Position = Vector3.new(side * 15.5, 2, riverZ + pz),
-				Color    = C.BRIDGE,
-				Material = MAT.WOOD,
-			})
-		end
-	end
-
-	-- Splash zone tag (vehicles entering water area near bridge edges get slowed)
-	local splash = _part(root, {
-		Name         = "MudZone_Bridge",
-		Size         = Vector3.new(10, 2, 28),
-		Position     = Vector3.new(-22, 0.6, riverZ),  -- water near left edge of track
-		Color        = C.RIVER,
-		Material     = MAT.WATER,
-		CanCollide   = false,
-		Transparency = 0.6,
-	})
-	_tag(splash, "MudZone")
-end
-
--- ─── Mud zones ────────────────────────────────────────────────────────────────
-
-local function _buildMudZones(root)
-	local zones = {
-		{ NODES[2][1] + 5,  1.2,  20, -50  },  -- near node 2
-		{ NODES[4][1] - 6,  1.2,  18, -210 },  -- near node 4
-		{ NODES[6][1] + 8,  1.2,  22, -440 },  -- near node 6
-		{ NODES[7][1] - 4,  1.2,  16, -490 },  -- node 7 stretch
-	}
-	for i, mz in ipairs(zones) do
-		local mud = _part(root, {
-			Name     = "MudZone_" .. i,
-			Size     = Vector3.new(mz[3], 0.4, mz[3]),
-			Position = Vector3.new(mz[1], mz[2], mz[4]),
-			Color    = C.MUD,
-			Material = MAT.MUD,
-		})
-		mud.CanCollide = false
-		_tag(mud, "MudZone")
-	end
-end
-
--- ─── Rock pile obstacles ──────────────────────────────────────────────────────
-
-local function _buildRockPiles(root)
-	local piles = {
-		{ NODES[2][1] - 8, NODES[2][2] - 45 },  -- left side of node 2 section
-		{ NODES[4][1] + 6, NODES[4][2] + 30 },  -- right side of node 4 section
-		{ NODES[5][1] - 8, NODES[5][2] + 40 },  -- node 5 approach
-		{ NODES[6][1] + 7, NODES[6][2] - 30 },  -- node 6 area
-		{ NODES[7][1],     NODES[7][2] + 30 },  -- near finish
-	}
-	for i, rp in ipairs(piles) do
-		local bx, bz = rp[1], rp[2]
-		-- Base boulder
-		local base = _part(root, {
-			Name     = "RockBase_" .. i,
-			Size     = Vector3.new(5, 4, 5),
-			Position = Vector3.new(bx, 2, bz),
-			Color    = C.ROCK,
-			Material = MAT.ROCK,
-		})
-		_tag(base, "Obstacle")
-
-		-- Stacked smaller rocks
-		_wedge(root, {
-			Name     = "RockChip1_" .. i,
-			Size     = Vector3.new(3, 2, 3),
-			Position = Vector3.new(bx + 2, 5, bz - 1),
-			Color    = C.ROCK_DARK,
-			Material = MAT.ROCK,
-		})
-		_part(root, {
-			Name     = "RockChip2_" .. i,
-			Size     = Vector3.new(2, 1.5, 2),
-			Position = Vector3.new(bx - 1.5, 5.5, bz + 1.5),
-			Color    = C.ROCK,
-			Material = MAT.ROCK,
-			CanCollide = false,
-		})
-
-		-- Moss accent
-		_part(root, {
-			Name     = "Moss_" .. i,
-			Size     = Vector3.new(5.2, 0.6, 5.2),
-			Position = Vector3.new(bx, 4.3, bz),
-			Color    = Color3.fromRGB(55, 110, 40),
-			Material = MAT.LEAVES,
 			CanCollide = false,
 			CastShadow = false,
 		})
 	end
 end
 
--- ─── Jump ramp ────────────────────────────────────────────────────────────────
+-- ─── Mud zones (S5 chicane area only — outside the racing line) ──────────────
+
+local function _buildMudZones(root)
+	-- Mud patches in the S-chicane apex sides (rewards apex cutting).
+	local zones = {
+		{ 230, -1560 },   -- outer of right chicane peak
+		{ -150, -1660 },  -- outer of left chicane peak
+		{   0, -1810 },   -- centerline mud just before finish straight (skill check)
+		{  50, -1700 },   -- inside chicane
+	}
+	for i, mz in ipairs(zones) do
+		local mud = _part(root, {
+			Name     = "MudZone_" .. i,
+			Size     = Vector3.new(20, 0.4, 16),
+			Position = Vector3.new(mz[1], 1.1, mz[2]),
+			Color    = C.MUD,
+			Material = MAT.MUD,
+		})
+		mud.CanCollide = false
+		mud.CastShadow = false
+		_tag(mud, "MudZone")
+	end
+end
+
+-- ─── Rock outcrop decor (S2 apex, OUTSIDE the wall) ──────────────────────────
+
+local function _buildRockDecor(root)
+	-- One landmark rock pile per drift corner / hairpin apex, all positioned
+	-- outside the corridor so vehicles cannot collide with them mid-race.
+	local piles = {
+		{ 110, -10 },      -- S2 outcrop (outer of right hairpin)
+		{ 620, -300 },     -- S3 outer bend at river mouth
+		{ -540, -1310 },   -- S4 U peak outer
+		{ 230, -1570 },    -- S5 chicane outer
+		{ -30,  100 },     -- S2 inner (left of corridor)
+	}
+	for i, rp in ipairs(piles) do
+		local bx, bz = rp[1], rp[2]
+		_part(root, {
+			Name = "RockBase_" .. i, Size = Vector3.new(7, 5, 7),
+			Position = Vector3.new(bx, 2.5, bz),
+			Color = C.ROCK, Material = MAT.ROCK,
+		})
+		_wedge(root, {
+			Name = "RockChip_" .. i, Size = Vector3.new(4, 3, 4),
+			Position = Vector3.new(bx + 2.5, 6.5, bz - 1.5),
+			Color = C.ROCK_DARK, Material = MAT.ROCK,
+		})
+		_part(root, {
+			Name = "Moss_" .. i, Size = Vector3.new(7.2, 0.6, 7.2),
+			Position = Vector3.new(bx, 5.3, bz),
+			Color = Color3.fromRGB(55, 110, 40), Material = MAT.LEAVES,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+end
+
+-- ─── Jump ramps (2 per spec, mid-S3 and pre-S5) ──────────────────────────────
+-- Ramp pieces are floor-only: thin wedge sitting on the track surface, no
+-- side collision walls (spec §2.4 fix for the "snag on prop side" cheese).
 
 local function _buildJumpRamps(root)
 	local ramps = {
-		{ NODES[3][1], NODES[3][2] - 30 },  -- mid left section
-		{ NODES[5][1], NODES[5][2] + 50 },  -- mid right section
+		{  490, -550, math.rad(35) },   -- mid-S3 over creek tributary
+		{    0, -1850, math.rad(0)  },  -- pre-finish straight (after chicane)
 	}
 	for i, r in ipairs(ramps) do
+		local rx, rz, yaw = r[1], r[2], r[3]
 		local ramp = _wedge(root, {
 			Name     = "JumpRamp_" .. i,
-			Size     = Vector3.new(TRACK_W, 5, 12),
+			Size     = Vector3.new(TRACK_W - 4, 4, 14),
 			Color    = C.RAMP,
 			Material = MAT.DIRT,
 		})
-		ramp.CFrame = CFrame.new(r[1], 3.5, r[2]) * CFrame.Angles(0, math.pi, 0)
+		ramp.CFrame = CFrame.new(rx, 3, rz) * CFrame.Angles(0, yaw + math.pi, 0)
 
+		-- Landing pad (flat slab matching track top — purely cosmetic since
+		-- the underlying TrackSeg already covers this Z).
 		_part(root, {
-			Name     = "LandingPad_" .. i,
-			Size     = Vector3.new(TRACK_W, 1, 22),
-			Position = Vector3.new(r[1], 1.5, r[2] - 17),  -- match track top = 1.0
-			Color    = C.RAMP,
-			Material = MAT.DIRT,
+			Name = "LandingPad_" .. i,
+			Size = Vector3.new(TRACK_W - 4, 0.2, 22),
+			Position = Vector3.new(rx, TRACK_TOP + 0.1, rz - 17 * math.cos(yaw)),
+			Color = C.RAMP, Material = MAT.DIRT,
+			CanCollide = false, CastShadow = false,
 		})
 
 		local jz = _part(root, {
-			Name     = "JumpZone_" .. i,
-			Size     = Vector3.new(TRACK_W, 10, 14),
-			Position = Vector3.new(r[1], 6, r[2]),
-			CanCollide  = false,
-			Transparency = 1,
+			Name = "JumpZone_" .. i, Size = Vector3.new(TRACK_W, 10, 14),
+			Position = Vector3.new(rx, 6, rz),
+			CanCollide = false, Transparency = 1,
 		})
 		_tag(jz, "JumpZone")
 	end
 end
 
--- ─── Boost pads ───────────────────────────────────────────────────────────────
+-- ─── Boost pads (4 per spec) ─────────────────────────────────────────────────
+-- Pads sit on the track surface as thin floor strips, CanCollide false.
 
 local function _buildBoostPads(root)
 	local pads = {
-		{ NODES[1][1], NODES[1][2] - 50 },   -- early track
-		{ NODES[3][1], NODES[3][2] + 20 },   -- entering left section
-		{ NODES[5][1], NODES[5][2] + 60 },   -- entering right section
-		{ NODES[7][1], NODES[7][2] + 20 },   -- late section
+		{   0,  400 },    -- S1 launch
+		{ 560, -380 },    -- S3 mid-sweep (rewards apex)
+		{ -380, -1500 },  -- S4 U exit
+		{   0, -1920 },   -- S5 onto finish straight
 	}
 	for i, pd in ipairs(pads) do
 		local pad = _part(root, {
-			Name     = "BoostPad_" .. i,
-			Size     = Vector3.new(10, 0.3, 6),
-			Position = Vector3.new(pd[1], 1.15, pd[2]),  -- on track surface (track top = 1.0)
-			Color    = C.BOOST_PAD,
-			Material = MAT.NEON,
-			CanCollide = false,
-			CastShadow = false,
+			Name = "BoostPad_" .. i,
+			Size = Vector3.new(10, 0.3, 8),
+			Position = Vector3.new(pd[1], TRACK_TOP + 0.2, pd[2]),
+			Color = C.BOOST_PAD, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
 		})
 		_tag(pad, "BoostPad")
 
 		local arrow = _wedge(root, {
-			Name     = "BoostArrow_" .. i,
-			Size     = Vector3.new(4, 0.4, 5),
-			Color    = Color3.fromRGB(255, 240, 80),
-			Material = MAT.NEON,
-			CanCollide = false,
-			CastShadow = false,
+			Name = "BoostArrow_" .. i,
+			Size = Vector3.new(5, 0.4, 5),
+			Color = Color3.fromRGB(255, 240, 80), Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
 		})
-		arrow.CFrame = CFrame.new(pd[1], 1.35, pd[2] - 4) * CFrame.Angles(0, math.pi, 0)
+		arrow.CFrame = CFrame.new(pd[1], TRACK_TOP + 0.4, pd[2] - 5) * CFrame.Angles(0, math.pi, 0)
 	end
 end
 
--- ─── Barrier chevrons at tight curves ─────────────────────────────────────────
-
-local function _buildBarriers(root)
-	-- Chevron warning barriers at the sharpest direction changes
-	local curveNodes = { 2, 4, 6 }  -- node indices where S-curves peak
-	for _, ni in ipairs(curveNodes) do
-		local nx, nz = NODES[ni][1], NODES[ni][2]
-		for _, side in ipairs({ -1, 1 }) do
-			for post = -1, 1, 1 do
-				_part(root, {
-					Name     = "Chevron",
-					Size     = Vector3.new(1.5, 4, 0.5),
-					Position = Vector3.new(nx + side * 18, 2, nz + post * 18),
-					Color    = Color3.fromRGB(240, 100, 30),
-					Material = MAT.NEON,
-					CanCollide = false,
-					CastShadow = false,
-				})
-			end
-		end
-	end
-end
-
--- ─── Three tree species ───────────────────────────────────────────────────────
-
-local function _buildTrees(root)
-	local rng = Random.new(42)
-
-	local function _pine(parent, tx, tz)
-		local h = rng:NextNumber(14, 24)
-		_part(parent, {
-			Name     = "PineTrunk",
-			Size     = Vector3.new(1, h, 1),
-			Position = Vector3.new(tx, h / 2, tz),
-			Color    = C.PINE_TRUNK,
-			Material = MAT.WOOD,
-			CanCollide = false,
-		})
-		-- 3-layer cone canopy stacked at the UPPER portion of the trunk.
-		-- Layer 0 (largest, bottom) at 65%, layer 1 at 80%, layer 2 (smallest, tip) at 95%.
-		for layer = 0, 2 do
-			local layerR = (3 - layer) * 2.5
-			local layerY = h * (0.65 + layer * 0.15)  -- 65%, 80%, 95% of trunk height
-			_part(parent, {
-				Name     = "PineLeaf",
-				Size     = Vector3.new(layerR * 2, layerR * 0.9, layerR * 2),
-				Position = Vector3.new(tx, layerY, tz),
-				Color    = layer % 2 == 0 and C.PINE_LEAF or C.PINE_LEAF2,
-				Material = MAT.LEAVES,
-				CanCollide = false,
-				CastShadow = false,
-			})
-		end
-	end
-
-	local function _oak(parent, tx, tz)
-		local h = rng:NextNumber(8, 15)
-		local r = rng:NextNumber(4, 8)
-		_part(parent, {
-			Name     = "OakTrunk",
-			Size     = Vector3.new(r * 0.45, h, r * 0.45),
-			Position = Vector3.new(tx, h / 2, tz),
-			Color    = C.OAK_TRUNK,
-			Material = MAT.WOOD,
-			CanCollide = false,
-		})
-		-- Wide rounded canopy (2 blobs)
-		for blob = 0, 1 do
-			_part(parent, {
-				Name     = "OakLeaf",
-				Size     = Vector3.new(r * 2.2, r * 1.4, r * 2.2),
-				Position = Vector3.new(tx, h + r * (0.4 + blob * 0.5), tz),
-				Color    = blob == 0 and C.OAK_LEAF or C.OAK_LEAF2,
-				Material = MAT.LEAVES,
-				CanCollide = false,
-				CastShadow = false,
-			})
-		end
-	end
-
-	local function _birch(parent, tx, tz)
-		local h = rng:NextNumber(10, 18)
-		_part(parent, {
-			Name     = "BirchTrunk",
-			Size     = Vector3.new(0.7, h, 0.7),
-			Position = Vector3.new(tx, h / 2, tz),
-			Color    = C.BIRCH_TRUNK,
-			Material = MAT.WOOD,
-			CanCollide = false,
-		})
-		-- Small oval canopy
-		_part(parent, {
-			Name     = "BirchLeaf",
-			Size     = Vector3.new(6, 7, 6),
-			Position = Vector3.new(tx, h + 2, tz),
-			Color    = C.BIRCH_LEAF,
-			Material = MAT.LEAVES,
-			CanCollide = false,
-			CastShadow = false,
-		})
-	end
-
-	local builders = { _pine, _pine, _oak, _oak, _birch }  -- weighted toward pine/oak
-	local zones = {
-		{ -55, -160, -600, 600, 38 },  -- left forest
-		{  55,  160, -600, 600, 38 },  -- right forest
-		{ -120, 120,  510, 660,  18 }, -- behind farm
-	}
-
-	for _, zone in ipairs(zones) do
-		local xMin, xMax, zMin, zMax, count = zone[1], zone[2], zone[3], zone[4], zone[5]
-		for _ = 1, count do
-			local tx  = rng:NextNumber(xMin, xMax)
-			local tz  = rng:NextNumber(zMin, zMax)
-			local fn  = builders[rng:NextInteger(1, #builders)]
-			fn(root, tx, tz)
-		end
-	end
-end
-
--- ─── Finish line ──────────────────────────────────────────────────────────────
-
-local function _buildFinishLine(root)
-	for col = -14, 14, 4 do
-		for row = 0, 1 do
-			_part(root, {
-				Name     = "FinishTile",
-				Size     = Vector3.new(4, 0.3, 4),
-				Position = Vector3.new(col, 1.15, -598 + row * 4),
-				Color    = (math.floor(col / 4) + row) % 2 == 0
-					and Color3.new(1,1,1) or Color3.new(0,0,0),
-				Material = MAT.METAL,
-				CanCollide = false,
-			})
-		end
-	end
-
-	local finish = _part(root, {
-		Name         = "FinishLine",
-		Size         = Vector3.new(32, 8, 2),
-		Position     = Vector3.new(0, 5, -599),  -- bottom at Y=1 (track surface), top at Y=9
-		CanCollide   = false,
-		Transparency = 1,
-	})
-	_tag(finish, "FinishLine")
-
-	for side = -1, 1, 2 do
-		_part(root, {
-			Name     = "FinishPole",
-			Size     = Vector3.new(1.5, 16, 1.5),
-			Position = Vector3.new(side * 17, 9, -599),
-			Color    = Color3.fromRGB(240, 240, 240),
-			Material = MAT.METAL,
-		})
-	end
-	_part(root, {
-		Name     = "FinishArch",
-		Size     = Vector3.new(36, 2.5, 1.5),
-		Position = Vector3.new(0, 18, -599),
-		Color    = Color3.fromRGB(220, 55, 55),
-		Material = MAT.NEON,
-		CanCollide = false,
-	})
-	-- Checkered arch banner
-	for bx = -16, 16, 8 do
-		_part(root, {
-			Name     = "ArchBanner",
-			Size     = Vector3.new(8, 4, 0.4),
-			Position = Vector3.new(bx, 15, -599),
-			Color    = math.abs(bx) % 16 == 0
-				and Color3.new(1,1,1) or Color3.new(0,0,0),
-			Material = MAT.METAL,
-			CanCollide = false,
-		})
-	end
-end
-
--- ─── Drift corner zones ───────────────────────────────────────────────────────
--- 4 trigger volumes at S-curve apexes. Tagged "DriftCorner" so RacingManager fires
--- DriftCharge to the player when their vehicle passes through.
--- Amber neon strips on the track surface visually mark each zone.
+-- ─── Drift corner zones (4 per spec §2.3) ────────────────────────────────────
 
 local function _buildDriftCorners(root)
 	local corners = {
-		{ NODES[2][1], NODES[2][2] },   -- Z= 45,  X=-22 (first left apex)
-		{ NODES[4][1], NODES[4][2] },   -- Z=-185, X=+20 (right apex)
-		{ NODES[6][1], NODES[6][2] },   -- Z=-415, X=-18 (second left apex)
-		-- midpoint of node 7→8: extra charge zone on final run-in
-		{
-			math.floor((NODES[7][1] + NODES[8][1]) / 2),
-			math.floor((NODES[7][2] + NODES[8][2]) / 2),
-		},
+		{  60,   30 }, -- S2 outcrop apex
+		{ 580, -300 }, -- S3 river bridge entry
+		{ -470, -1310 }, -- S4 U peak
+		{ 180, -1550 }, -- S5 chicane entry
 	}
 	for i, c in ipairs(corners) do
 		local cx, cz = c[1], c[2]
-		-- Amber neon strip (visual)
 		_part(root, {
 			Name         = "DriftStrip_" .. i,
 			Size         = Vector3.new(TRACK_W - 2, 0.2, 38),
-			Position     = Vector3.new(cx, 1.12, cz),
+			Position     = Vector3.new(cx, TRACK_TOP + 0.12, cz),
 			Color        = Color3.fromRGB(255, 165, 20),
-			Material     = Enum.Material.Neon,
+			Material     = MAT.NEON,
 			CanCollide   = false,
 			CastShadow   = false,
 			Transparency = 0.55,
 		})
-		-- Invisible trigger (tagged)
 		local trigger = _part(root, {
 			Name         = "DriftCorner_" .. i,
 			Size         = Vector3.new(TRACK_W, 5, 40),
@@ -739,18 +561,192 @@ local function _buildDriftCorners(root)
 	end
 end
 
--- ─── Start grid ───────────────────────────────────────────────────────────────
+-- ─── Checkpoints (CP1 inside S3 sweeper, CP2 inside S4 U-bend) ───────────────
+-- Per spec §2.6: positioned so any straight-line outside-the-corridor path
+-- geometrically misses the trigger volumes. CheckpointService (#126) gates the
+-- FinishLine on cp1 && cp2.
+
+local function _buildCheckpoints(root)
+	local cp1 = _part(root, {
+		Name         = "Checkpoint1",
+		Size         = Vector3.new(TRACK_W, 12, 6),
+		Position     = Vector3.new(130, 7, -820),  -- N14, inside S3 sweeper apex
+		CanCollide   = false,
+		Transparency = 1,
+	})
+	_tag(cp1, "Checkpoint1")
+
+	local cp2 = _part(root, {
+		Name         = "Checkpoint2",
+		Size         = Vector3.new(TRACK_W, 12, 6),
+		Position     = Vector3.new(-470, 7, -1310), -- N19, inside U-bend peak
+		CanCollide   = false,
+		Transparency = 1,
+	})
+	_tag(cp2, "Checkpoint2")
+end
+
+-- ─── Three tree species (relocated OUTSIDE walls per §2.7) ───────────────────
+
+local function _buildTrees(root)
+	local rng = Random.new(42)
+
+	local function _pine(parent, tx, tz)
+		local h = rng:NextNumber(14, 24)
+		_part(parent, {
+			Name = "PineTrunk", Size = Vector3.new(1, h, 1),
+			Position = Vector3.new(tx, h / 2, tz),
+			Color = C.PINE_TRUNK, Material = MAT.WOOD, CanCollide = false,
+		})
+		for layer = 0, 2 do
+			local layerR = (3 - layer) * 2.5
+			local layerY = h * (0.65 + layer * 0.15)
+			_part(parent, {
+				Name = "PineLeaf", Size = Vector3.new(layerR * 2, layerR * 0.9, layerR * 2),
+				Position = Vector3.new(tx, layerY, tz),
+				Color = layer % 2 == 0 and C.PINE_LEAF or C.PINE_LEAF2,
+				Material = MAT.LEAVES, CanCollide = false, CastShadow = false,
+			})
+		end
+	end
+
+	local function _oak(parent, tx, tz)
+		local h = rng:NextNumber(8, 15)
+		local r = rng:NextNumber(4, 8)
+		_part(parent, {
+			Name = "OakTrunk", Size = Vector3.new(r * 0.45, h, r * 0.45),
+			Position = Vector3.new(tx, h / 2, tz),
+			Color = C.OAK_TRUNK, Material = MAT.WOOD, CanCollide = false,
+		})
+		for blob = 0, 1 do
+			_part(parent, {
+				Name = "OakLeaf", Size = Vector3.new(r * 2.2, r * 1.4, r * 2.2),
+				Position = Vector3.new(tx, h + r * (0.4 + blob * 0.5), tz),
+				Color = blob == 0 and C.OAK_LEAF or C.OAK_LEAF2,
+				Material = MAT.LEAVES, CanCollide = false, CastShadow = false,
+			})
+		end
+	end
+
+	local function _birch(parent, tx, tz)
+		local h = rng:NextNumber(10, 18)
+		_part(parent, {
+			Name = "BirchTrunk", Size = Vector3.new(0.7, h, 0.7),
+			Position = Vector3.new(tx, h / 2, tz),
+			Color = C.BIRCH_TRUNK, Material = MAT.WOOD, CanCollide = false,
+		})
+		_part(parent, {
+			Name = "BirchLeaf", Size = Vector3.new(6, 7, 6),
+			Position = Vector3.new(tx, h + 2, tz),
+			Color = C.BIRCH_LEAF, Material = MAT.LEAVES,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+
+	-- Helper: reject tree positions that fall within the corridor bbox.
+	local function _insideTrack(tx, tz)
+		-- Approximate: trees too close to any node are likely on the track.
+		for _, n in ipairs(NODES) do
+			local dx, dz = tx - n[1], tz - n[2]
+			if dx * dx + dz * dz < 35 * 35 then  -- 35-stud buffer (track is 40 wide)
+				return true
+			end
+		end
+		return false
+	end
+
+	local builders = { _pine, _pine, _oak, _oak, _birch }
+	local zones = {
+		-- (xMin, xMax, zMin, zMax, count)
+		{ -550, -100,   100,  700, 30 },  -- left of S1/farm
+		{  100,  550,   100,  700, 30 },  -- right of S1/farm
+		{ -550,    0,  -700,    0, 35 },  -- inside arc of S2/S3 sweeper (left)
+		{  650, 1100,  -500,  100, 25 },  -- right of S3 outer sweep
+		{ -800, -550, -1700, -700, 35 },  -- outside U-bend west side
+		{  100,  700, -1700, -700, 30 },  -- inside U-bend east side
+		{ -500,  500, -2200, -1700, 30 }, -- around finish-line approach
+	}
+
+	for _, zone in ipairs(zones) do
+		local xMin, xMax, zMin, zMax, count = zone[1], zone[2], zone[3], zone[4], zone[5]
+		local placed, attempts = 0, 0
+		while placed < count and attempts < count * 6 do
+			attempts = attempts + 1
+			local tx = rng:NextNumber(xMin, xMax)
+			local tz = rng:NextNumber(zMin, zMax)
+			if not _insideTrack(tx, tz) then
+				local fn = builders[rng:NextInteger(1, #builders)]
+				fn(root, tx, tz)
+				placed = placed + 1
+			end
+		end
+	end
+end
+
+-- ─── Finish line ──────────────────────────────────────────────────────────────
+
+local function _buildFinishLine(root)
+	-- Checker tiles either side of the finish sensor.
+	for col = -18, 18, 4 do
+		for row = 0, 1 do
+			_part(root, {
+				Name = "FinishTile",
+				Size = Vector3.new(4, 0.3, 4),
+				Position = Vector3.new(col, TRACK_TOP + 0.15, FINISH_Z + row * 4),
+				Color = (math.floor(col / 4) + row) % 2 == 0
+					and Color3.new(1,1,1) or Color3.new(0,0,0),
+				Material = MAT.METAL,
+				CanCollide = false,
+			})
+		end
+	end
+
+	local finish = _part(root, {
+		Name         = "FinishLine",
+		Size         = Vector3.new(TRACK_W, 10, 2),
+		Position     = Vector3.new(0, 6, FINISH_Z),
+		CanCollide   = false,
+		Transparency = 1,
+	})
+	_tag(finish, "FinishLine")
+
+	for side = -1, 1, 2 do
+		_part(root, {
+			Name = "FinishPole",
+			Size = Vector3.new(1.5, 18, 1.5),
+			Position = Vector3.new(side * (TRACK_W / 2 + 1), 10, FINISH_Z),
+			Color = Color3.fromRGB(240, 240, 240), Material = MAT.METAL,
+		})
+	end
+	_part(root, {
+		Name = "FinishArch", Size = Vector3.new(TRACK_W + 4, 2.5, 1.5),
+		Position = Vector3.new(0, 20, FINISH_Z),
+		Color = Color3.fromRGB(220, 55, 55), Material = MAT.NEON,
+		CanCollide = false,
+	})
+	for bx = -20, 20, 8 do
+		_part(root, {
+			Name = "ArchBanner",
+			Size = Vector3.new(8, 4, 0.4),
+			Position = Vector3.new(bx, 16, FINISH_Z),
+			Color = math.abs(bx) % 16 == 0 and Color3.new(1,1,1) or Color3.new(0,0,0),
+			Material = MAT.METAL, CanCollide = false,
+		})
+	end
+end
+
+-- ─── Start grid (matches BiomeConfig.FOREST.raceStartZ = 590) ────────────────
 
 local function _buildStartGrid(root)
-	local cols = { -14, -7, 0, 7, 14 }  -- match CraftingManager spawn grid x=(col-3)*7
-	local rows = { 195, 203 }           -- match BiomeConfig raceStartZ=195, row2 offset +8
+	local cols = { -14, -7, 0, 7, 14 }
+	local rows = { 590, 598 }
 	for ri, z in ipairs(rows) do
 		for ci, x in ipairs(cols) do
 			local idx = (ri - 1) * 5 + ci
 			_part(root, {
 				Name     = "StartBox_" .. idx,
 				Size     = Vector3.new(7, 0.2, 7),
-				Position = Vector3.new(x, 1.05, z),  -- sit on track surface (track top = 1.0)
+				Position = Vector3.new(x, TRACK_TOP + 0.05, z),
 				Color    = Color3.fromRGB(60, 120, 255),
 				Material = MAT.NEON,
 				CanCollide = false,
@@ -764,28 +760,29 @@ end
 local function buildForest()
 	local root = _getOrCreateMap()
 
-	-- Sub-models so MapManager can toggle farm vs track visibility per phase
 	local farmSub  = Instance.new("Model"); farmSub.Name  = "FarmArea";  farmSub.Parent  = root
 	local trackSub = Instance.new("Model"); trackSub.Name = "RaceTrack"; trackSub.Parent = root
 
-	_buildGround(root)           -- shared ground plane
-	_buildTrees(root)            -- shared decoration
+	_buildGround(root)
+	_buildTrees(root)
 	_buildFarmArea(farmSub)
+
 	_buildTrack(trackSub)
+	_buildWalls(trackSub)
 	_buildRiverBridge(trackSub)
 	_buildMudZones(trackSub)
-	_buildRockPiles(trackSub)
+	_buildRockDecor(trackSub)
 	_buildJumpRamps(trackSub)
 	_buildBoostPads(trackSub)
-	_buildBarriers(trackSub)
 	_buildDriftCorners(trackSub)
+	_buildCheckpoints(trackSub)
 	_buildFinishLine(trackSub)
 	_buildStartGrid(trackSub)
 
 	CollectionService:AddTag(root, "BiomeMap")
 	root:SetAttribute("Biome", "FOREST")
 
-	print("[ForestMapBuilder] Built FOREST map (" .. #root:GetChildren() .. " objects)")
+	print("[ForestMapBuilder] Built FOREST map (" .. #root:GetDescendants() .. " descendants)")
 	return root
 end
 

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -1,22 +1,31 @@
 -- OceanMapBuilder.server.lua
--- Procedurally builds the OCEAN biome map:
---   - Open water plane with farm island
---   - S-curve race course marked by buoys (3 corners at Z=0, -180, -360)
---   - Buoyancy zones, boost pads, drift corner zones, obstacles, finish line
--- Resolves: Issue #9, #114
+-- Procedurally builds the OCEAN biome map per racetrack spec §3:
+--   - 3400-stud centerline (arc-S + island detour + reef U-bend) along Z=600 → -1500
+--   - 60-wide channel with solid above-water reef walls both sides (height 12 above waterPlaneY=2)
+--   - Enlarged palm island anchors the S2 arc; reef formation anchors the S4 U-bend
+--   - Buoys reduced to centerline decoration only (CanCollide false)
+--   - CP1 inside S2 island arc, CP2 inside S4 reef U-bend
+-- Resolves: Issue #9, #114, #129
 
 local CollectionService = game:GetService("CollectionService")
 
 local C = {
-	WATER      = Color3.fromRGB(30,  90,  180),
-	DOCK       = Color3.fromRGB(140, 100, 60),
-	SAND       = Color3.fromRGB(220, 190, 120),
-	BOOST      = Color3.fromRGB(60,  200, 255),
-	PALM_TRUNK = Color3.fromRGB(120, 85,  40),
-	PALM_LEAF  = Color3.fromRGB(60,  160, 50),
-	BUOY_RED   = Color3.fromRGB(220, 50,  50),
-	BUOY_WHITE = Color3.fromRGB(240, 240, 240),
-	DRIFT_GLOW = Color3.fromRGB(40,  220, 255),
+	WATER       = Color3.fromRGB(30,  90,  180),
+	WATER_DEEP  = Color3.fromRGB(8,   35,  90),
+	WATER_MID   = Color3.fromRGB(12,  55,  140),
+	WATER_TOP   = Color3.fromRGB(25,  105, 210),
+	WATER_FOAM  = Color3.fromRGB(120, 200, 255),
+	DOCK        = Color3.fromRGB(140, 100, 60),
+	SAND        = Color3.fromRGB(220, 190, 120),
+	BOOST       = Color3.fromRGB(60,  200, 255),
+	PALM_TRUNK  = Color3.fromRGB(120, 85,  40),
+	PALM_LEAF   = Color3.fromRGB(60,  160, 50),
+	BUOY_RED    = Color3.fromRGB(220, 50,  50),
+	BUOY_WHITE  = Color3.fromRGB(240, 240, 240),
+	DRIFT_GLOW  = Color3.fromRGB(40,  220, 255),
+	REEF        = Color3.fromRGB(95,  75,  55),
+	REEF_TOP    = Color3.fromRGB(220, 60,  60),
+	GRASS       = Color3.fromRGB(80,  160, 70),
 }
 
 local MAT = {
@@ -26,11 +35,14 @@ local MAT = {
 	METAL  = Enum.Material.Metal,
 	NEON   = Enum.Material.Neon,
 	LEAVES = Enum.Material.LeafyGrass,
+	GRASS  = Enum.Material.Grass,
+	ROCK   = Enum.Material.Rock,
 }
 
-local WATER_Y       = 2    -- WaterPlane top face at Y=2
-local COURSE_HALF_W = 25   -- half-width of race lane (50 studs total)
-local BUOY_INTERVAL = 60   -- studs between buoy pairs
+local WATER_Y  = 2     -- water surface Y
+local LANE_W   = 60    -- channel width (spec §3 table)
+local WALL_H   = 12    -- reef wall height above water (spec §3.4)
+local FINISH_Z = -1500 -- matches Constants.TRACK.OCEAN.zFinish
 
 local function _part(parent, props)
 	local p = Instance.new("Part")
@@ -57,89 +69,198 @@ local function _getOrCreateMap()
 	return model
 end
 
--- ─── S-curve course centerline ────────────────────────────────────────────────
--- Three corners at Z=0, Z=-180, Z=-360 (matching neon arch markers).
---   Z ≥  0:          straight,     center X = 0
---   Z  0 → -180:    swing LEFT,   center X = 0  → -22
---   Z -180 → -360:  swing RIGHT,  center X = -22 → +22
---   Z -360 → -580:  return centre, center X = +22 →  0
+-- ─── Channel centerline (spec §3.1, arc-S + island detour + reef U-bend) ─────
 
-local function _cX(z)
-	if z >= 0 then
-		return 0
-	elseif z >= -180 then
-		return -22 * (-z / 180)
-	elseif z >= -360 then
-		local t = (-z - 180) / 180
-		return -22 + 44 * t
-	elseif z >= -580 then
-		local t = (-z - 360) / 220
-		return 22 - 22 * t
-	end
-	return 0
+local NODES = {
+	-- S1 Harbor Launch (~350)
+	{   0,  600 }, -- N1  start dock
+	{   0,  250 }, -- N2  enter S2
+
+	-- S2 Island Arc east around enlarged palm island (~600)
+	{  60,  200 }, -- N3
+	{ 140,  100 }, -- N4
+	{ 180,    0 }, -- N5  CP1 zone (apex east)
+	{ 160, -100 }, -- N6
+	{  80, -180 }, -- N7
+	{   0, -200 }, -- N8  exit S2
+
+	-- S3 Open Channel (chicane + jump skill-shot) (~520)
+	{   0, -300 }, -- N9
+	{  40, -400 }, -- N10
+	{   0, -500 }, -- N11
+	{ -40, -600 }, -- N12
+	{   0, -700 }, -- N13
+
+	-- S4 Reef U-bend east around reef formation (~900)
+	{  40,  -730 }, -- N14
+	{ 180,  -730 }, -- N15
+	{ 330,  -800 }, -- N16
+	{ 380,  -900 }, -- N17  CP2 zone (apex south-east)
+	{ 330, -1000 }, -- N18
+	{ 180, -1010 }, -- N19
+	{  40, -1000 }, -- N20
+
+	-- S5 Return Channel + Finish Lagoon (~720)
+	{   0, -1080 }, -- N21
+	{  80, -1150 }, -- N22
+	{   0, -1220 }, -- N23
+	{ -80, -1290 }, -- N24
+	{   0, -1360 }, -- N25
+	{  80, -1430 }, -- N26
+	{   0, -1500 }, -- N27 FinishLine sensor at zFinish
+	{   0, -1560 }, -- N28 runoff past finish
+}
+
+local function _segCF(ax, az, bx, bz, y)
+	local mx, mz = (ax + bx) * 0.5, (az + bz) * 0.5
+	local rotY   = math.atan2(bx - ax, bz - az)
+	return CFrame.new(mx, y, mz) * CFrame.Angles(0, rotY, 0)
 end
 
--- ─── Water plane ─────────────────────────────────────────────────────────────
+local function _segLen(ax, az, bx, bz)
+	local dx, dz = bx - ax, bz - az
+	return math.sqrt(dx * dx + dz * dz)
+end
+
+-- ─── Water plane (large, covers full bbox of all nodes plus reef walls) ──────
 
 local function _buildWater(root)
+	-- Deep ocean floor
 	_part(root, {
-		Name = "OceanFloor", Size = Vector3.new(800, 2, 1800),
-		Position = Vector3.new(0, WATER_Y - 14, 0),
-		Color = Color3.fromRGB(8, 35, 90), Material = Enum.Material.SmoothPlastic,
+		Name = "OceanFloor", Size = Vector3.new(1400, 2, 2600),
+		Position = Vector3.new(0, WATER_Y - 14, -400),
+		Color = C.WATER_DEEP, Material = Enum.Material.SmoothPlastic,
 		CanCollide = false, CastShadow = false,
 	})
+	-- Mid water volume
 	_part(root, {
-		Name = "WaterVolume", Size = Vector3.new(700, 12, 1700),
-		Position = Vector3.new(0, WATER_Y - 8, 0),
-		Color = Color3.fromRGB(12, 55, 140), Material = Enum.Material.SmoothPlastic,
+		Name = "WaterVolume", Size = Vector3.new(1300, 12, 2500),
+		Position = Vector3.new(0, WATER_Y - 8, -400),
+		Color = C.WATER_MID, Material = Enum.Material.SmoothPlastic,
 		Transparency = 0.15, CanCollide = false, CastShadow = false,
 	})
+	-- Surface
 	_part(root, {
-		Name = "WaterPlane", Size = Vector3.new(600, 4, 1600),
-		Position = Vector3.new(0, WATER_Y - 2, 0),
-		Color = Color3.fromRGB(25, 105, 210), Material = MAT.WATER,
+		Name = "WaterPlane", Size = Vector3.new(1200, 4, 2400),
+		Position = Vector3.new(0, WATER_Y - 2, -400),
+		Color = C.WATER_TOP, Material = MAT.WATER,
 		Transparency = 0.35, CanCollide = false,
 	})
+	-- Foam shimmer overlay
 	_part(root, {
-		Name = "WaterShimmer", Size = Vector3.new(600, 0.25, 1600),
-		Position = Vector3.new(0, WATER_Y, 0),
-		Color = Color3.fromRGB(120, 200, 255), Material = Enum.Material.Neon,
+		Name = "WaterShimmer", Size = Vector3.new(1200, 0.25, 2400),
+		Position = Vector3.new(0, WATER_Y, -400),
+		Color = C.WATER_FOAM, Material = MAT.NEON,
 		Transparency = 0.82, CanCollide = false, CastShadow = false,
 	})
 end
 
--- ─── Farm island (Z = 250 to 500) ────────────────────────────────────────────
+-- ─── Channel "lane" cosmetic strip (slightly tinted water on centerline) ─────
 
-local function _buildFarmIsland(root)
+local function _buildLaneStrip(root)
+	for i = 1, #NODES - 1 do
+		local a, b   = NODES[i], NODES[i + 1]
+		local segLen = _segLen(a[1], a[2], b[1], b[2])
+		local cf     = _segCF(a[1], a[2], b[1], b[2], WATER_Y - 0.05)
+		local strip = _part(root, {
+			Name     = "LaneStrip_" .. i,
+			Size     = Vector3.new(LANE_W - 4, 0.15, segLen + 4),
+			Color    = Color3.fromRGB(80, 180, 255),
+			Material = MAT.NEON,
+			Transparency = 0.6,
+			CanCollide = false,
+			CastShadow = false,
+		})
+		strip.CFrame = cf
+	end
+end
+
+-- ─── Reef walls (spec §3.4): solid above-water at ±30 stud offset ────────────
+
+local function _buildReefWalls(root)
+	for i = 1, #NODES - 1 do
+		local a, b   = NODES[i], NODES[i + 1]
+		local segLen = _segLen(a[1], a[2], b[1], b[2])
+		local cf     = _segCF(a[1], a[2], b[1], b[2], WATER_Y + WALL_H / 2)
+
+		for _, side in ipairs({ -1, 1 }) do
+			local wall = _part(root, {
+				Name     = "ReefWall",
+				Size     = Vector3.new(3, WALL_H, segLen + 8),  -- +8: adjacent walls overlap at joints
+				Color    = C.REEF,
+				Material = MAT.ROCK,
+			})
+			wall.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), 0, 0)
+
+			-- Red top stripe for visibility
+			local cap = _part(root, {
+				Name     = "ReefWallCap",
+				Size     = Vector3.new(3.4, 0.6, segLen + 8),
+				Color    = C.REEF_TOP,
+				Material = MAT.NEON,
+				CastShadow = false,
+			})
+			cap.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), WALL_H / 2 + 0.3, 0)
+		end
+	end
+end
+
+-- ─── Buoyancy zones covering the entire channel bbox ─────────────────────────
+
+local function _buildBuoyancyZones(root)
+	local z = _part(root, {
+		Name = "BuoyancyZone_Main", Size = Vector3.new(1200, 8, 2400),
+		Position = Vector3.new(0, WATER_Y - 1, -400),
+		CanCollide = false, Transparency = 1,
+	})
+	_tag(z, "BuoyancyZone")
+end
+
+-- ─── Buoys (decorative only — CanCollide false, centerline guidance) ─────────
+
+local function _buildCourseBuoys(root)
+	-- Place pairs at evenly-spaced node positions
+	local buoyIdx = 0
+	for i = 2, #NODES - 1, 2 do
+		buoyIdx = buoyIdx + 1
+		local cx, cz = NODES[i][1], NODES[i][2]
+		local isRedSide = (buoyIdx % 2 == 0)
+		for _, side in ipairs({ -1, 1 }) do
+			local isRed = (side == 1) == isRedSide
+			local bx = cx + side * (LANE_W / 2 - 6)  -- inside the wall, on the lane edge
+			_part(root, {
+				Name     = "Buoy_" .. buoyIdx .. (side > 0 and "R" or "L"),
+				Size     = Vector3.new(2.5, 4, 2.5),
+				Position = Vector3.new(bx, WATER_Y + 2, cz),
+				Color    = isRed and C.BUOY_RED or C.BUOY_WHITE,
+				Material = MAT.NEON,
+				CanCollide = false,  -- decorative per spec §3.4
+				CastShadow = false,
+			})
+		end
+	end
+end
+
+-- ─── Palm island (S2 inside arc, enlarged so arc-cut is solid land) ─────────
+-- Inside the S2 arc, X≈+90 Z≈0; island prevents straight-line shortcut.
+
+local function _buildPalmIsland(root)
+	local cx, cz = 90, 0  -- inside the arc's east bulge
 	_part(root, {
-		Name = "FarmIsland", Size = Vector3.new(160, 6, 260),
-		Position = Vector3.new(0, WATER_Y - 1, 375),
+		Name = "Palm_IslandBase", Size = Vector3.new(110, 8, 220),
+		Position = Vector3.new(cx, WATER_Y - 2, cz),
 		Color = C.SAND, Material = MAT.SAND,
 	})
 	_part(root, {
-		Name = "FarmGrass", Size = Vector3.new(140, 1, 230),
-		Position = Vector3.new(0, WATER_Y + 2.5, 375),
-		Color = Color3.fromRGB(80, 160, 70), Material = Enum.Material.Grass,
+		Name = "Palm_IslandGrass", Size = Vector3.new(95, 1.5, 200),
+		Position = Vector3.new(cx, WATER_Y + 2.5, cz),
+		Color = C.GRASS, Material = MAT.GRASS,
 	})
-
-	local cols = { -50, -25, 0, 25, 50 }
-	local rows = { 290, 330 }
-	for _, row in ipairs(rows) do
-		for _, col in ipairs(cols) do
-			local sp = _part(root, {
-				Name = "FarmSpawnPoint", Size = Vector3.new(4, 0.5, 4),
-				Position = Vector3.new(col, WATER_Y + 3.5, row),
-				Color = Color3.fromRGB(255, 220, 60), Material = MAT.NEON,
-				CanCollide = false, Transparency = 0.5,
-			})
-			_tag(sp, "FarmSpawn")
-		end
-	end
 
 	local rng = Random.new(99)
 	for _ = 1, 8 do
-		local tx = rng:NextNumber(-60, 60)
-		local tz = rng:NextNumber(260, 490)
+		local tx = rng:NextNumber(cx - 40, cx + 40)
+		local tz = rng:NextNumber(cz - 90, cz + 90)
 		local h  = rng:NextNumber(8, 14)
 		_part(root, {
 			Name = "PalmTrunk", Size = Vector3.new(1.2, h, 1.2),
@@ -159,158 +280,196 @@ local function _buildFarmIsland(root)
 	end
 end
 
--- ─── Buoyancy zones ──────────────────────────────────────────────────────────
--- Expanded X width (110) covers course shifts: ±(22 center + 25 half-width) = ±47.
+-- ─── Reef formation (S4 inside U-bend; visual landmark / shortcut blocker) ──
 
-local function _buildBuoyancyZones(root)
-	local z1 = _part(root, {
-		Name = "BuoyancyZone_Main", Size = Vector3.new(110, 6, 900),
-		Position = Vector3.new(0, WATER_Y - 1, -200), CanCollide = false, Transparency = 1,
+local function _buildReefFormation(root)
+	-- Inside the U-bend at approximately (220, -870)
+	local cx, cz = 220, -870
+	-- Submerged base
+	_part(root, {
+		Name = "ReefBase", Size = Vector3.new(80, 6, 140),
+		Position = Vector3.new(cx, WATER_Y - 3, cz),
+		Color = C.REEF, Material = MAT.ROCK,
 	})
-	_tag(z1, "BuoyancyZone")
-
-	local z2 = _part(root, {
-		Name = "BuoyancyZone_Start", Size = Vector3.new(110, 6, 200),
-		Position = Vector3.new(0, WATER_Y - 1, 130), CanCollide = false, Transparency = 1,
-	})
-	_tag(z2, "BuoyancyZone")
-end
-
--- ─── S-curve course buoys ─────────────────────────────────────────────────────
--- Each pair is offset by _cX(z) so boundaries follow the curve.
-
-local function _buildCourseBuoys(root)
-	local buoyIdx = 0
-	for z = 180, -580, -BUOY_INTERVAL do
-		buoyIdx = buoyIdx + 1
-		local isRedSide = (buoyIdx % 2 == 0)
-		local cx = _cX(z)
-
-		for _, side in ipairs({ -1, 1 }) do
-			local isRed = (side == 1) == isRedSide
-			local bx = cx + side * COURSE_HALF_W
-
-			local body = _part(root, {
-				Name     = "Buoy_" .. buoyIdx .. (side > 0 and "R" or "L"),
-				Size     = Vector3.new(2.5, 4, 2.5),
-				Position = Vector3.new(bx, WATER_Y + 2, z),
-				Color    = isRed and C.BUOY_RED or C.BUOY_WHITE,
-				Material = MAT.NEON,
-			})
-			_tag(body, "Obstacle")
-
-			_part(root, {
-				Name     = "BuoyChain_" .. buoyIdx .. (side > 0 and "R" or "L"),
-				Size     = Vector3.new(0.3, 4, 0.3),
-				Position = Vector3.new(bx, WATER_Y - 2, z),
-				Color    = Color3.fromRGB(80, 80, 80), Material = MAT.METAL,
-				CanCollide = false,
-			})
-		end
-	end
-end
-
--- ─── Turn markers ─────────────────────────────────────────────────────────────
--- Neon arches positioned on the course centerline at each S-curve apex.
-
-local function _buildTurnMarkers(root)
-	local turns = {
-		{ 0,    _cX(-90)  },   -- first swing apex (use midpoint Z=-90 for visual centering)
-		{ -180, _cX(-180) },   -- second apex: X=-22
-		{ -360, _cX(-360) },   -- third apex: X=+22
-		{ -520, _cX(-520) },   -- finish approach
-	}
-	for i, t in ipairs(turns) do
-		local tz = t[1]
-		local cx = t[2]
+	-- Spires above water (above waterPlaneY, visible)
+	for i = 1, 5 do
+		local sx = cx + (i - 3) * 14
+		local sz = cz + math.sin(i) * 30
 		_part(root, {
-			Name = "TurnArch_L" .. i, Size = Vector3.new(2, 12, 2),
-			Position = Vector3.new(cx - COURSE_HALF_W - 2, WATER_Y + 6, tz),
-			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
+			Name = "ReefSpire_" .. i,
+			Size = Vector3.new(8, 10, 8),
+			Position = Vector3.new(sx, WATER_Y + 4, sz),
+			Color = C.REEF, Material = MAT.ROCK,
 		})
 		_part(root, {
-			Name = "TurnArch_R" .. i, Size = Vector3.new(2, 12, 2),
-			Position = Vector3.new(cx + COURSE_HALF_W + 2, WATER_Y + 6, tz),
-			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
-		})
-		_part(root, {
-			Name = "TurnArch_Top" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 8, 2, 2),
-			Position = Vector3.new(cx, WATER_Y + 12, tz),
-			Color = Color3.fromRGB(40, 200, 255), Material = MAT.NEON, CanCollide = false,
+			Name = "ReefSpireTip_" .. i,
+			Size = Vector3.new(4, 4, 4),
+			Position = Vector3.new(sx, WATER_Y + 10, sz),
+			Color = C.REEF_TOP, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
 		})
 	end
 end
 
--- ─── Drift corner zones ───────────────────────────────────────────────────────
--- 3 trigger volumes at S-curve apexes; cyan wake rings mark them visually.
+-- ─── Drift corners (3 per spec §3.3) ─────────────────────────────────────────
 
 local function _buildDriftCorners(root)
 	local corners = {
-		{ -180, _cX(-180) },   -- apex 1: X=-22 (left)
-		{ -360, _cX(-360) },   -- apex 2: X=+22 (right)
-		{ -470, _cX(-470) },   -- apex 3: X≈+9  (return leg)
+		{ 180,    0 }, -- S2 island arc apex (N5)
+		{ 380, -900 }, -- S4 reef U-bend apex (N17)
+		{   0, -1220 }, -- S5 return channel mid-zigzag (N23)
 	}
 	for i, c in ipairs(corners) do
-		local cz, cx = c[1], c[2]
-
-		-- Cyan wake ring (visual)
+		local cx, cz = c[1], c[2]
 		_part(root, {
-			Name = "WakeRing_" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 4, 0.3, 42),
+			Name = "WakeRing_" .. i, Size = Vector3.new(LANE_W - 4, 0.3, 42),
 			Position = Vector3.new(cx, WATER_Y + 0.3, cz),
 			Color = C.DRIFT_GLOW, Material = MAT.NEON,
-			CanCollide = false, CastShadow = false, Transparency = 0.52,
+			CanCollide = false, CastShadow = false, Transparency = 0.5,
 		})
-
-		-- Invisible trigger
 		local trigger = _part(root, {
-			Name = "DriftCorner_" .. i, Size = Vector3.new(COURSE_HALF_W * 2 + 22, 8, 46),
-			Position = Vector3.new(cx, WATER_Y + 1, cz),
+			Name = "DriftCorner_" .. i, Size = Vector3.new(LANE_W + 20, 8, 46),
+			Position = Vector3.new(cx, WATER_Y + 2, cz),
 			CanCollide = false, Transparency = 1,
 		})
 		_tag(trigger, "DriftCorner")
 	end
 end
 
--- ─── Boost pads (on S-curve centerline) ──────────────────────────────────────
+-- ─── Jump ramps (2 per spec — post-S2 wave swell + mid-S3 skill-shot) ────────
+
+local function _buildJumpRamps(root)
+	local ramps = {
+		{ 0, -240 },   -- post-S2 wave swell (between N8 and N9)
+		{ 0, -500 },   -- mid-S3 skill shot (N11)
+	}
+	for i, r in ipairs(ramps) do
+		local rx, rz = r[1], r[2]
+		_part(root, {
+			Name = "WaveRamp_" .. i, Size = Vector3.new(LANE_W - 12, 1.5, 14),
+			Position = Vector3.new(rx, WATER_Y + 1, rz),
+			Color = C.WATER_FOAM, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false, Transparency = 0.3,
+		})
+		local jz = _part(root, {
+			Name = "JumpZone_" .. i, Size = Vector3.new(LANE_W - 6, 8, 12),
+			Position = Vector3.new(rx, WATER_Y + 4, rz),
+			CanCollide = false, Transparency = 1,
+		})
+		_tag(jz, "JumpZone")
+	end
+end
+
+-- ─── Boost pads (4 per spec §3.3) ────────────────────────────────────────────
 
 local function _buildBoostPads(root)
-	local padZs = { 60, -100, -280, -450 }
-	for i, z in ipairs(padZs) do
-		local cx = _cX(z)
+	local pads = {
+		{   0,  500 },   -- S1 launch
+		{ 150,    0 },   -- S2 inner apex (rewards tight line)
+		{   0, -550 },   -- S3 mid-channel
+		{   0, -1080 },  -- post-S4 U-bend exit (N21)
+	}
+	for i, pd in ipairs(pads) do
 		local pad = _part(root, {
 			Name = "BoostPad_" .. i, Size = Vector3.new(12, 0.4, 8),
-			Position = Vector3.new(cx, WATER_Y + 0.4, z),
+			Position = Vector3.new(pd[1], WATER_Y + 0.4, pd[2]),
 			Color = C.BOOST, Material = MAT.NEON, CanCollide = false,
 		})
 		_tag(pad, "BoostPad")
 		_part(root, {
 			Name = "BoostRing_" .. i, Size = Vector3.new(16, 0.2, 12),
-			Position = Vector3.new(cx, WATER_Y + 0.3, z),
+			Position = Vector3.new(pd[1], WATER_Y + 0.3, pd[2]),
 			Color = Color3.fromRGB(100, 240, 255), Material = MAT.NEON,
 			Transparency = 0.5, CanCollide = false,
 		})
 	end
 end
 
--- ─── Start grid ──────────────────────────────────────────────────────────────
+-- ─── Checkpoints (spec §3.6) ─────────────────────────────────────────────────
+
+local function _buildCheckpoints(root)
+	local cp1 = _part(root, {
+		Name = "Checkpoint1", Size = Vector3.new(LANE_W, 12, 6),
+		Position = Vector3.new(180, WATER_Y + 5, 0),  -- N5 inside island arc
+		CanCollide = false, Transparency = 1,
+	})
+	_tag(cp1, "Checkpoint1")
+
+	local cp2 = _part(root, {
+		Name = "Checkpoint2", Size = Vector3.new(LANE_W, 12, 6),
+		Position = Vector3.new(380, WATER_Y + 5, -900),  -- N17 inside reef U-bend
+		CanCollide = false, Transparency = 1,
+	})
+	_tag(cp2, "Checkpoint2")
+end
+
+-- ─── Farm area (FARMING phase only; hidden during RACING) ────────────────────
+-- Relocated to a separate island behind the start dock (Z=700–1000).
+
+local function _buildFarmIsland(root)
+	local cx, cz = 0, 850
+	_part(root, {
+		Name = "FarmIsland", Size = Vector3.new(180, 6, 260),
+		Position = Vector3.new(cx, WATER_Y - 1, cz),
+		Color = C.SAND, Material = MAT.SAND,
+	})
+	_part(root, {
+		Name = "FarmGrass", Size = Vector3.new(160, 1, 230),
+		Position = Vector3.new(cx, WATER_Y + 2.5, cz),
+		Color = C.GRASS, Material = MAT.GRASS,
+	})
+
+	local cols = { -60, -30, 0, 30, 60 }
+	local rows = { cz - 50, cz + 50 }
+	for _, rz in ipairs(rows) do
+		for _, cxx in ipairs(cols) do
+			local sp = _part(root, {
+				Name = "FarmSpawnPoint", Size = Vector3.new(4, 0.5, 4),
+				Position = Vector3.new(cx + cxx, WATER_Y + 3.5, rz),
+				Color = Color3.fromRGB(255, 220, 60), Material = MAT.NEON,
+				CanCollide = false, Transparency = 0.5,
+			})
+			_tag(sp, "FarmSpawn")
+		end
+	end
+
+	local rng = Random.new(7)
+	for _ = 1, 8 do
+		local tx = rng:NextNumber(cx - 70, cx + 70)
+		local tz = rng:NextNumber(cz - 100, cz + 100)
+		local h  = rng:NextNumber(8, 14)
+		_part(root, {
+			Name = "PalmTrunk", Size = Vector3.new(1.2, h, 1.2),
+			Position = Vector3.new(tx, WATER_Y + 2.5 + h / 2, tz),
+			Color = C.PALM_TRUNK, Material = MAT.WOOD, CanCollide = false,
+		})
+		_part(root, {
+			Name = "PalmCanopy", Size = Vector3.new(6, 4, 6),
+			Position = Vector3.new(tx, WATER_Y + 2.5 + h + 1, tz),
+			Color = C.PALM_LEAF, Material = MAT.LEAVES, CanCollide = false,
+		})
+	end
+end
+
+-- ─── Start grid (matches BiomeConfig.OCEAN.raceStartZ = 590) ─────────────────
 
 local function _buildStartGrid(root)
 	_part(root, {
-		Name = "StartDock", Size = Vector3.new(COURSE_HALF_W * 2, 1, 20),
-		Position = Vector3.new(0, WATER_Y + 0.5, 200),
+		Name = "StartDock", Size = Vector3.new(LANE_W - 6, 1, 24),
+		Position = Vector3.new(0, WATER_Y + 0.5, 595),
 		Color = C.DOCK, Material = MAT.WOOD,
 	})
 	for side = -1, 1, 2 do
 		_part(root, {
 			Name = "StartPole" .. (side > 0 and "R" or "L"),
 			Size = Vector3.new(1.5, 10, 1.5),
-			Position = Vector3.new(side * (COURSE_HALF_W + 1), WATER_Y + 5, 192),
+			Position = Vector3.new(side * (LANE_W / 2 - 3), WATER_Y + 5, 588),
 			Color = C.BUOY_WHITE, Material = MAT.METAL,
 		})
 	end
 	_part(root, {
-		Name = "StartBanner", Size = Vector3.new(COURSE_HALF_W * 2 + 4, 2, 1),
-		Position = Vector3.new(0, WATER_Y + 10, 192),
+		Name = "StartBanner", Size = Vector3.new(LANE_W - 4, 2, 1),
+		Position = Vector3.new(0, WATER_Y + 10, 588),
 		Color = Color3.fromRGB(255, 220, 40), Material = MAT.NEON, CanCollide = false,
 	})
 end
@@ -318,12 +477,12 @@ end
 -- ─── Finish line ─────────────────────────────────────────────────────────────
 
 local function _buildFinishLine(root)
-	for col = -COURSE_HALF_W, COURSE_HALF_W - 4, 4 do
+	for col = -(LANE_W / 2), (LANE_W / 2) - 4, 4 do
 		for row = 0, 1 do
 			_part(root, {
 				Name = "FinishTile", Size = Vector3.new(4, 0.4, 4),
-				Position = Vector3.new(col + 2, WATER_Y + 0.4, -596 + row * 4),
-				Color = (math.floor((col + COURSE_HALF_W) / 4) + row) % 2 == 0
+				Position = Vector3.new(col + 2, WATER_Y + 0.4, FINISH_Z + row * 4),
+				Color = (math.floor((col + LANE_W / 2) / 4) + row) % 2 == 0
 					and Color3.new(1,1,1) or Color3.new(0,0,0),
 				Material = MAT.METAL, CanCollide = false,
 			})
@@ -331,8 +490,8 @@ local function _buildFinishLine(root)
 	end
 
 	local finish = _part(root, {
-		Name = "FinishLine", Size = Vector3.new(COURSE_HALF_W * 2, 8, 2),
-		Position = Vector3.new(0, WATER_Y + 4, -598),
+		Name = "FinishLine", Size = Vector3.new(LANE_W - 4, 10, 2),
+		Position = Vector3.new(0, WATER_Y + 5, FINISH_Z),
 		CanCollide = false, Transparency = 1,
 	})
 	_tag(finish, "FinishLine")
@@ -340,14 +499,14 @@ local function _buildFinishLine(root)
 	for side = -1, 1, 2 do
 		_part(root, {
 			Name = "FinishPole" .. (side > 0 and "R" or "L"),
-			Size = Vector3.new(1.5, 16, 1.5),
-			Position = Vector3.new(side * (COURSE_HALF_W + 2), WATER_Y + 8, -598),
+			Size = Vector3.new(1.5, 18, 1.5),
+			Position = Vector3.new(side * (LANE_W / 2 - 2), WATER_Y + 9, FINISH_Z),
 			Color = C.BUOY_WHITE, Material = MAT.METAL,
 		})
 	end
 	_part(root, {
-		Name = "FinishArch", Size = Vector3.new(COURSE_HALF_W * 2 + 6, 2, 1.5),
-		Position = Vector3.new(0, WATER_Y + 16, -598),
+		Name = "FinishArch", Size = Vector3.new(LANE_W, 2.5, 1.5),
+		Position = Vector3.new(0, WATER_Y + 18, FINISH_Z),
 		Color = Color3.fromRGB(40, 160, 255), Material = MAT.NEON, CanCollide = false,
 	})
 end
@@ -363,17 +522,23 @@ local function buildOcean()
 	_buildWater(root)
 	_buildBuoyancyZones(root)
 	_buildFarmIsland(farmSub)
+
+	_buildPalmIsland(trackSub)
+	_buildReefFormation(trackSub)
+	_buildLaneStrip(trackSub)
+	_buildReefWalls(trackSub)
 	_buildCourseBuoys(trackSub)
-	_buildTurnMarkers(trackSub)
 	_buildBoostPads(trackSub)
+	_buildJumpRamps(trackSub)
 	_buildDriftCorners(trackSub)
+	_buildCheckpoints(trackSub)
 	_buildStartGrid(trackSub)
 	_buildFinishLine(trackSub)
 
 	CollectionService:AddTag(root, "BiomeMap")
 	root:SetAttribute("Biome", "OCEAN")
 
-	print("[OceanMapBuilder] Built OCEAN map (" .. #root:GetChildren() .. " objects)")
+	print("[OceanMapBuilder] Built OCEAN map (" .. #root:GetDescendants() .. " descendants)")
 	return root
 end
 

--- a/roblox/ServerScriptService/Modules/BiomeConfig.lua
+++ b/roblox/ServerScriptService/Modules/BiomeConfig.lua
@@ -10,7 +10,7 @@ BiomeConfig["FOREST"] = {
 	mapPath        = "Workspace.Maps.ForestMap",
 	vehicleType    = "Car",
 	mobilitySlot   = "WHEELS",
-	raceStartZ     = 195,   -- just before track node[1] at Z=175
+	raceStartZ     = 590,   -- just before track node[1] at Z=600 (Constants.TRACK.FOREST.zStart)
 	raceStartY     = 2,
 	skyboxId       = "rbxassetid://0",          -- TODO: replace with asset IDs
 	ambientSoundId = "rbxassetid://0",          -- TODO

--- a/roblox/ServerScriptService/Modules/BiomeConfig.lua
+++ b/roblox/ServerScriptService/Modules/BiomeConfig.lua
@@ -39,12 +39,13 @@ BiomeConfig["OCEAN"] = {
 	mapPath        = "Workspace.Maps.OceanMap",
 	vehicleType    = "Boat",
 	mobilitySlot   = "SAIL",
-	raceStartZ     = 175,   -- just before dock node[1] at Z=155
-	raceStartY     = 3,     -- WATER_Y(0) + dock(1.5) + clearance(1.5)
+	raceStartZ     = 590,   -- just before track node[1] at Z=600 (Constants.TRACK.OCEAN.zStart)
+	raceStartY     = 3,     -- WATER_Y(2) + dock(1) clearance
 	skyboxId       = "rbxassetid://0",
 	ambientSoundId = "rbxassetid://0",
 
-	waterPlaneY    = 2,                         -- Y coordinate of water surface (raised above baseplate)
+	waterPlaneY    = 2,                         -- Y coordinate of water surface
+	killPlaneY     = -10,                       -- boat that sinks below water surface = respawn (belt-and-suspenders OOB)
 
 	hazards = {
 		{

--- a/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
@@ -324,6 +324,90 @@ RemoteEvents.DriftCharge.OnClientEvent:Connect(function(amount)
 	end
 end)
 
+-- ─── Checkpoint indicator (Issue #131) ────────────────────────────────────────
+-- Shows CP1 / CP2 progress so players understand why a finish-line touch
+-- doesn't count. Server gating lives in CheckpointService (Issue #126).
+
+local _cpFrame   = nil
+local _cpLabels  = { nil, nil }
+local _cpPassed  = { false, false }
+
+local CP_INACTIVE_COLOR = Color3.fromRGB(180, 180, 195)
+local CP_PASSED_COLOR   = Color3.fromRGB(80, 230, 120)
+
+local function _ensureCheckpointHUD()
+	if _cpFrame and _cpFrame.Parent then return _cpFrame end
+	local overlay = _getOverlay()
+	local frame = Instance.new("Frame")
+	frame.Name        = "CheckpointIndicator"
+	frame.Size        = UDim2.new(0, 200, 0, 32)
+	frame.AnchorPoint = Vector2.new(0.5, 0)
+	frame.Position    = UDim2.new(0.5, 0, 0, 16)
+	frame.BackgroundColor3 = Color3.fromRGB(20, 20, 30)
+	frame.BackgroundTransparency = 0.4
+	frame.BorderSizePixel = 0
+	frame.Parent      = overlay
+
+	local corner = Instance.new("UICorner")
+	corner.CornerRadius = UDim.new(0, 6)
+	corner.Parent = frame
+
+	for i = 1, 2 do
+		local lbl = Instance.new("TextLabel")
+		lbl.Name           = "CP" .. i
+		lbl.Size           = UDim2.new(0.5, -4, 1, -4)
+		lbl.Position       = UDim2.new((i - 1) * 0.5, 2, 0, 2)
+		lbl.BackgroundTransparency = 1
+		lbl.Font           = Enum.Font.GothamBold
+		lbl.TextScaled     = true
+		lbl.TextStrokeTransparency = 0.5
+		lbl.Text           = "CP" .. i .. "  ☐"
+		lbl.TextColor3     = CP_INACTIVE_COLOR
+		lbl.Parent         = frame
+		_cpLabels[i] = lbl
+	end
+
+	_cpFrame = frame
+	return frame
+end
+
+local function _updateCheckpointHUD()
+	_ensureCheckpointHUD()
+	for i = 1, 2 do
+		local lbl = _cpLabels[i]
+		if lbl then
+			lbl.Text       = "CP" .. i .. (_cpPassed[i] and "  ✓" or "  ☐")
+			lbl.TextColor3 = _cpPassed[i] and CP_PASSED_COLOR or CP_INACTIVE_COLOR
+		end
+	end
+end
+
+local function _resetCheckpointHUD()
+	_cpPassed[1] = false
+	_cpPassed[2] = false
+	_updateCheckpointHUD()
+end
+
+local function _flashCheckpoint(cpIndex)
+	local lbl = _cpLabels[cpIndex]
+	if not lbl then return end
+	local original = lbl.TextSize
+	TweenService:Create(lbl, TweenInfo.new(0.15, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {
+		TextTransparency = 0,
+	}):Play()
+	_applyScreenTint(CP_PASSED_COLOR, 0.15, 0.2)
+end
+
+if RemoteEvents.CheckpointPassed then
+	RemoteEvents.CheckpointPassed.OnClientEvent:Connect(function(cpIndex)
+		if cpIndex == 1 or cpIndex == 2 then
+			_cpPassed[cpIndex] = true
+			_updateCheckpointHUD()
+			_flashCheckpoint(cpIndex)
+		end
+	end)
+end
+
 -- ─── Vehicle drive loop ───────────────────────────────────────────────────────
 
 local function _driveLoop()
@@ -528,6 +612,7 @@ function RacingClient.enable()
 	_drifting     = false
 	_abilityIndex = 1
 	_updateBoostHUD()
+	_resetCheckpointHUD()
 
 	local hum = LocalPlayer.Character and LocalPlayer.Character:FindFirstChildOfClass("Humanoid")
 	if hum then hum.JumpHeight = 0 end


### PR DESCRIPTION
## Summary
PRs #134 (FOREST #128), #135 (OCEAN #129), #137 (CheckpointUI #131) were merged into each other's feature branches as a stack but the chain never reached `main`. Only SKY was rescued separately via #150. This PR cherry-picks the three orphaned squash commits onto `main`.

Commits cherry-picked, in dependency order:
- `bf54ce4` ← `03daf1e` — `feat(#128): rebuild FOREST track per plan §2 (#134)`
- `f0186cb` ← `5368a84` — `feat(#129): rebuild OCEAN track per plan §3 (#135)`
- `c623daa` ← `dcb1aeb` — `feat(#131): add checkpoint indicator UI (#137)`

Each picked cleanly (auto-merge on `BiomeConfig.lua` / `RacingClient.client.lua`, no conflicts).

After this lands, FOREST and OCEAN biomes get the walled, checkpoint-gated tracks from the 5/14 plan, and the in-race HUD shows CP1/CP2 progress.

## Test plan
- [ ] Race in FOREST: walls solid both directions, CP1/CP2 indicator updates, finish gates on both checkpoints
- [ ] Race in OCEAN: same checks; verify no boat shortcut around palm island / reef
- [ ] Race in SKY: existing rebuild still works (sanity)
- [ ] CheckpointUI shows nothing in farming phase, appears at race start