### PR TITLE
feat: checkpoint arch gates + hide labels during FARMING

### DIFF
--- a/roblox/ReplicatedStorage/RemoteEvents/init.lua
+++ b/roblox/ReplicatedStorage/RemoteEvents/init.lua
@@ -21,6 +21,8 @@
 --   ScreenEffect        → (effectName: string, params: table) -- client-side VFX
 --   DriftCharge         → (amount: number)  -- boost gauge fill from DriftCorner zone
 --   CheckpointPassed    → (cpIndex: number)  -- fires to passing player only (1 or 2)
+--   RaceIntroShown      → (intro: { biome: string })  -- broadcast at race start
+--   RaceSeedBroadcast   → (seed: number)  -- per-race seed for client-side variation
 --
 -- RemoteFunctions (server-authoritative):
 --   RequestPickup       → itemId: string          → "ok" | "denied: <reason>"
@@ -51,6 +53,8 @@ local EVENTS = {
 	"ScreenEffect",
 	"DriftCharge",
 	"CheckpointPassed",
+	"RaceIntroShown",
+	"RaceSeedBroadcast",
 }
 
 local FUNCTIONS = {

--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -566,6 +566,50 @@ end
 -- geometrically misses the trigger volumes. CheckpointService (#126) gates the
 -- FinishLine on cp1 && cp2.
 
+local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
+	local groundY = 0
+	local archTop = groundY + 18
+	for _, side in ipairs({ -1, 1 }) do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Pillar" .. (side > 0 and "R" or "L"),
+			Size = Vector3.new(2.4, archTop, 2.4),
+			Position = Vector3.new(x + side * (TRACK_W / 2 - 2), groundY + archTop / 2, z),
+			Color = archColor, Material = Enum.Material.Neon,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	for i = -1, 1 do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Top" .. (i + 2),
+			Size = Vector3.new(TRACK_W / 3 + 2, 2, 2.4),
+			Position = Vector3.new(x + i * (TRACK_W / 3), archTop + (i == 0 and 2 or 0.5), z),
+			Color = archColor, Material = Enum.Material.Neon,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	local labelAnchor = _part(root, {
+		Name = "CPGate" .. cpIndex .. "Label",
+		Size = Vector3.new(1, 1, 1),
+		Position = Vector3.new(x, archTop + 8, z),
+		Transparency = 1, CanCollide = false, CastShadow = false,
+	})
+	local bb = Instance.new("BillboardGui")
+	bb.Size           = UDim2.new(0, 120, 0, 32)
+	bb.MaxDistance    = 300
+	bb.LightInfluence = 0
+	bb.Parent         = labelAnchor
+	local lbl = Instance.new("TextLabel")
+	lbl.Size = UDim2.fromScale(1, 1)
+	lbl.BackgroundTransparency = 1
+	lbl.Text = "체크포인트 " .. cpIndex
+	lbl.TextColor3 = archColor
+	lbl.TextStrokeColor3 = Color3.new(0, 0, 0)
+	lbl.TextStrokeTransparency = 0.2
+	lbl.Font = Enum.Font.GothamBlack
+	lbl.TextScaled = true
+	lbl.Parent = bb
+end
+
 local function _buildCheckpoints(root)
 	local cp1 = _part(root, {
 		Name         = "Checkpoint1",
@@ -575,6 +619,7 @@ local function _buildCheckpoints(root)
 		Transparency = 1,
 	})
 	_tag(cp1, "Checkpoint1")
+	_buildCheckpointGate(root, 130, -820, 1, Color3.fromRGB(120, 220, 255))
 
 	local cp2 = _part(root, {
 		Name         = "Checkpoint2",
@@ -584,6 +629,7 @@ local function _buildCheckpoints(root)
 		Transparency = 1,
 	})
 	_tag(cp2, "Checkpoint2")
+	_buildCheckpointGate(root, -470, -1310, 2, Color3.fromRGB(255, 200, 100))
 end
 
 -- ─── Three tree species (relocated OUTSIDE walls per §2.7) ───────────────────

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -387,6 +387,50 @@ end
 
 -- ─── Checkpoints (spec §3.6) ─────────────────────────────────────────────────
 
+local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
+	local baseY = WATER_Y + 1
+	local archTop = baseY + 20
+	for _, side in ipairs({ -1, 1 }) do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Pillar" .. (side > 0 and "R" or "L"),
+			Size = Vector3.new(2.4, archTop - baseY, 2.4),
+			Position = Vector3.new(x + side * (LANE_W / 2 - 2), (baseY + archTop) / 2, z),
+			Color = archColor, Material = Enum.Material.Neon,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	for i = -1, 1 do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Top" .. (i + 2),
+			Size = Vector3.new(LANE_W / 3 + 2, 2, 2.4),
+			Position = Vector3.new(x + i * (LANE_W / 3), archTop + (i == 0 and 2 or 0.5), z),
+			Color = archColor, Material = Enum.Material.Neon,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	local labelAnchor = _part(root, {
+		Name = "CPGate" .. cpIndex .. "Label",
+		Size = Vector3.new(1, 1, 1),
+		Position = Vector3.new(x, archTop + 8, z),
+		Transparency = 1, CanCollide = false, CastShadow = false,
+	})
+	local bb = Instance.new("BillboardGui")
+	bb.Size           = UDim2.new(0, 120, 0, 32)
+	bb.MaxDistance    = 300
+	bb.LightInfluence = 0
+	bb.Parent         = labelAnchor
+	local lbl = Instance.new("TextLabel")
+	lbl.Size = UDim2.fromScale(1, 1)
+	lbl.BackgroundTransparency = 1
+	lbl.Text = "체크포인트 " .. cpIndex
+	lbl.TextColor3 = archColor
+	lbl.TextStrokeColor3 = Color3.new(0, 0, 0)
+	lbl.TextStrokeTransparency = 0.2
+	lbl.Font = Enum.Font.GothamBlack
+	lbl.TextScaled = true
+	lbl.Parent = bb
+end
+
 local function _buildCheckpoints(root)
 	local cp1 = _part(root, {
 		Name = "Checkpoint1", Size = Vector3.new(LANE_W, 12, 6),
@@ -394,6 +438,7 @@ local function _buildCheckpoints(root)
 		CanCollide = false, Transparency = 1,
 	})
 	_tag(cp1, "Checkpoint1")
+	_buildCheckpointGate(root, 180, 0, 1, Color3.fromRGB(120, 220, 255))
 
 	local cp2 = _part(root, {
 		Name = "Checkpoint2", Size = Vector3.new(LANE_W, 12, 6),
@@ -401,6 +446,7 @@ local function _buildCheckpoints(root)
 		CanCollide = false, Transparency = 1,
 	})
 	_tag(cp2, "Checkpoint2")
+	_buildCheckpointGate(root, 380, -900, 2, Color3.fromRGB(255, 200, 100))
 end
 
 -- ─── Farm area (FARMING phase only; hidden during RACING) ────────────────────

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -422,22 +422,78 @@ local function _buildBoostPads(root)
 end
 
 -- ─── Checkpoints (spec §4.6) ─────────────────────────────────────────────────
+-- Each checkpoint = invisible Touched trigger (gated by CheckpointService)
+-- + visible glowing arch so players know where to drive through.
+
+local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
+	local archY = SKY_BASE_Y + 22
+	-- Two pillars at corridor edges
+	for _, side in ipairs({ -1, 1 }) do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Pillar" .. (side > 0 and "R" or "L"),
+			Size = Vector3.new(2.4, 38, 2.4),
+			Position = Vector3.new(x + side * (CORRIDOR_W / 2 - 2), SKY_BASE_Y + 19, z),
+			Color = archColor, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	-- Curved top: 3 segments faking an arch
+	local topY = archY + 6
+	for i = -1, 1 do
+		_part(root, {
+			Name = "CPGate" .. cpIndex .. "Top" .. (i + 2),
+			Size = Vector3.new(CORRIDOR_W / 3 + 2, 2, 2.4),
+			Position = Vector3.new(x + i * (CORRIDOR_W / 3), topY + (i == 0 and 1.5 or 0), z),
+			Color = archColor, Material = MAT.NEON,
+			CanCollide = false, CastShadow = false,
+		})
+	end
+	-- Floating "CP1" / "CP2" label
+	local labelAnchor = _part(root, {
+		Name = "CPGate" .. cpIndex .. "Label",
+		Size = Vector3.new(1, 1, 1),
+		Position = Vector3.new(x, topY + 6, z),
+		Transparency = 1, CanCollide = false, CastShadow = false,
+	})
+	local bb = Instance.new("BillboardGui")
+	bb.Size           = UDim2.new(0, 120, 0, 32)
+	bb.StudsOffset    = Vector3.new(0, 0, 0)
+	bb.MaxDistance    = 300
+	bb.LightInfluence = 0
+	bb.Parent         = labelAnchor
+	local lbl = Instance.new("TextLabel")
+	lbl.Size                   = UDim2.fromScale(1, 1)
+	lbl.BackgroundTransparency = 1
+	lbl.Text                   = "체크포인트 " .. cpIndex
+	lbl.TextColor3             = archColor
+	lbl.TextStrokeColor3       = Color3.new(0, 0, 0)
+	lbl.TextStrokeTransparency = 0.2
+	lbl.Font                   = Enum.Font.GothamBlack
+	lbl.TextScaled             = true
+	lbl.Parent                 = bb
+end
 
 local function _buildCheckpoints(root)
+	local cp1Pos = { x = -600, z = 800 }   -- N8 Loop A western extent
+	local cp2Pos = { x = 600,  z = 400 }   -- N18 Loop B eastern extent
+
 	local cp1 = _part(root, {
 		Name = "Checkpoint1",
 		Size = Vector3.new(CORRIDOR_W, 50, 6),
-		Position = Vector3.new(-600, SKY_BASE_Y + 25, 800),  -- N8 Loop A western extent
+		Position = Vector3.new(cp1Pos.x, SKY_BASE_Y + 25, cp1Pos.z),
 		CanCollide = false, Transparency = 1,
 	})
 	_tag(cp1, "Checkpoint1")
+	_buildCheckpointGate(root, cp1Pos.x, cp1Pos.z, 1, Color3.fromRGB(120, 220, 255))
+
 	local cp2 = _part(root, {
 		Name = "Checkpoint2",
 		Size = Vector3.new(CORRIDOR_W, 50, 6),
-		Position = Vector3.new(600, SKY_BASE_Y + 25, 400),  -- N18 Loop B eastern extent
+		Position = Vector3.new(cp2Pos.x, SKY_BASE_Y + 25, cp2Pos.z),
 		CanCollide = false, Transparency = 1,
 	})
 	_tag(cp2, "Checkpoint2")
+	_buildCheckpointGate(root, cp2Pos.x, cp2Pos.z, 2, Color3.fromRGB(255, 200, 100))
 end
 
 -- ─── Farm platform (relocated north of start, beyond track Z extent) ─────────

--- a/roblox/ServerScriptService/MapManager.server.lua
+++ b/roblox/ServerScriptService/MapManager.server.lua
@@ -172,6 +172,11 @@ local function _setSubVisible(biome, subName, visible)
 				desc.Transparency = 1
 				desc.CanCollide   = false
 			end
+		elseif desc:IsA("BillboardGui") or desc:IsA("SurfaceGui") then
+			-- GUIs ignore the Part.Transparency of their adornee, so the
+			-- transparency loop above won't hide their text. Without this
+			-- branch the floating checkpoint labels stayed visible all phases.
+			desc.Enabled = visible
 		end
 	end
 end

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -23,6 +23,7 @@ local _biome       = nil
 local _startTick   = 0
 local _finishOrder = {}   -- { { userId, time } }
 local _totalRacers = 0
+local _raceSeed    = 0    -- broadcast to clients for per-race variation
 
 -- Per-player physics state
 -- _physState[userId] = {
@@ -527,6 +528,11 @@ GameManager.onPhaseChanged(function(phase, biome)
 
 		_setupFinishLine()
 		_startPositionSync()
+
+		-- Broadcast race intro overlay + per-race seed (for client variation)
+		RemoteEvents.RaceIntroShown:FireAllClients({ biome = biome })
+		_raceSeed = math.random(1, 1000000)
+		RemoteEvents.RaceSeedBroadcast:FireAllClients(_raceSeed)
 
 	elseif phase == Constants.PHASES.RESULTS then
 		_active = false

--- a/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
@@ -361,7 +361,7 @@ local function _ensureCheckpointHUD()
 		lbl.Font           = Enum.Font.GothamBold
 		lbl.TextScaled     = true
 		lbl.TextStrokeTransparency = 0.5
-		lbl.Text           = "CP" .. i .. "  ☐"
+		lbl.Text           = i .. "번 ☐"
 		lbl.TextColor3     = CP_INACTIVE_COLOR
 		lbl.Parent         = frame
 		_cpLabels[i] = lbl
@@ -376,7 +376,7 @@ local function _updateCheckpointHUD()
 	for i = 1, 2 do
 		local lbl = _cpLabels[i]
 		if lbl then
-			lbl.Text       = "CP" .. i .. (_cpPassed[i] and "  ✓" or "  ☐")
+			lbl.Text       = i .. "번 " .. (_cpPassed[i] and "✓" or "☐")
 			lbl.TextColor3 = _cpPassed[i] and CP_PASSED_COLOR or CP_INACTIVE_COLOR
 		end
 	end
@@ -398,13 +398,112 @@ local function _flashCheckpoint(cpIndex)
 	_applyScreenTint(CP_PASSED_COLOR, 0.15, 0.2)
 end
 
+local function _showCheckpointPassToast(cpIndex)
+	local overlay = _getOverlay()
+	local lbl = overlay:FindFirstChild("CPPassToast")
+	if not lbl then
+		lbl = Instance.new("TextLabel")
+		lbl.Name                   = "CPPassToast"
+		lbl.Size                   = UDim2.new(0, 280, 0, 56)
+		lbl.AnchorPoint            = Vector2.new(0.5, 0)
+		lbl.Position               = UDim2.new(0.5, 0, 0, 72)
+		lbl.BackgroundTransparency = 1
+		lbl.TextScaled             = true
+		lbl.Font                   = Enum.Font.GothamBlack
+		lbl.TextStrokeTransparency = 0.3
+		lbl.Parent                 = overlay
+	end
+	lbl.Text             = "체크포인트 " .. cpIndex .. " 통과! ✓"
+	lbl.TextColor3       = CP_PASSED_COLOR
+	lbl.TextTransparency = 0
+	TweenService:Create(lbl, TweenInfo.new(1.2, Enum.EasingStyle.Quad), {
+		TextTransparency = 1,
+	}):Play()
+end
+
 if RemoteEvents.CheckpointPassed then
 	RemoteEvents.CheckpointPassed.OnClientEvent:Connect(function(cpIndex)
 		if cpIndex == 1 or cpIndex == 2 then
 			_cpPassed[cpIndex] = true
 			_updateCheckpointHUD()
 			_flashCheckpoint(cpIndex)
+			_showCheckpointPassToast(cpIndex)
 		end
+	end)
+end
+
+-- ─── Race intro overlay (Issue #131 follow-up) ────────────────────────────────
+-- Shown once at race start: explains the CP1/CP2 gating rule so players know
+-- they need to drive through both arches before the finish line counts.
+
+local function _showRaceIntro()
+	_resetCheckpointHUD()
+	local overlay = _getOverlay()
+	local existing = overlay:FindFirstChild("RaceIntroBanner")
+	if existing then existing:Destroy() end
+
+	local frame = Instance.new("Frame")
+	frame.Name                   = "RaceIntroBanner"
+	frame.Size                   = UDim2.new(0, 540, 0, 96)
+	frame.AnchorPoint            = Vector2.new(0.5, 0.5)
+	frame.Position               = UDim2.new(0.5, 0, 0.42, 0)
+	frame.BackgroundColor3       = Color3.fromRGB(15, 18, 28)
+	frame.BackgroundTransparency = 0.2
+	frame.BorderSizePixel        = 0
+	frame.Parent                 = overlay
+	local corner = Instance.new("UICorner")
+	corner.CornerRadius = UDim.new(0, 10)
+	corner.Parent = frame
+
+	local title = Instance.new("TextLabel")
+	title.Size                   = UDim2.new(1, -20, 0, 36)
+	title.Position               = UDim2.new(0, 10, 0, 8)
+	title.BackgroundTransparency = 1
+	title.Text                   = "🏁 레이스 시작!"
+	title.TextColor3             = Color3.fromRGB(255, 220, 80)
+	title.Font                   = Enum.Font.GothamBlack
+	title.TextScaled             = true
+	title.TextStrokeTransparency = 0.4
+	title.Parent                 = frame
+
+	local body = Instance.new("TextLabel")
+	body.Size                    = UDim2.new(1, -20, 0, 44)
+	body.Position                = UDim2.new(0, 10, 0, 46)
+	body.BackgroundTransparency  = 1
+	body.Text                    = "1번 → 2번 체크포인트 아치를 순서대로 통과한 뒤 결승선!"
+	body.TextColor3              = Color3.fromRGB(220, 230, 245)
+	body.Font                    = Enum.Font.GothamBold
+	body.TextScaled              = true
+	body.TextStrokeTransparency  = 0.5
+	body.Parent                  = frame
+
+	task.delay(2.8, function()
+		if not frame.Parent then return end
+		local tw = TweenService:Create(frame, TweenInfo.new(0.6, Enum.EasingStyle.Quad), {
+			BackgroundTransparency = 1,
+		})
+		tw:Play()
+		for _, child in ipairs(frame:GetDescendants()) do
+			if child:IsA("TextLabel") then
+				TweenService:Create(child, TweenInfo.new(0.6), { TextTransparency = 1, TextStrokeTransparency = 1 }):Play()
+			end
+		end
+		tw.Completed:Wait()
+		frame:Destroy()
+	end)
+end
+
+if RemoteEvents.RaceIntroShown then
+	RemoteEvents.RaceIntroShown.OnClientEvent:Connect(function(_intro)
+		_showRaceIntro()
+	end)
+end
+
+-- Store per-race seed broadcast (placeholder for future client-side variation)
+local _raceSeed = nil
+if RemoteEvents.RaceSeedBroadcast then
+	RemoteEvents.RaceSeedBroadcast.OnClientEvent:Connect(function(seed)
+		_raceSeed = seed
 	end)
 end
 


### PR DESCRIPTION
## Summary
체크포인트에 글로잉 아치/라벨을 세우는 미커밋 작업을 정리해서 PR로 올리고, 동시에 플레이테스트에서 지적된 가시성/명확성 문제를 같은 PR에서 수정.

## 문제 (스크린샷)
- 파밍 중에도 거대한 "CP1 / CP2" 라벨이 공중에 떠 보임.
- "CP1/CP2"는 사용자가 의미를 알 수 없는 약어.
- 라벨이 지형 너머까지 그대로 비쳐서 거리감이 없음.

## 원인
- 가시성 토글(`_setSubVisible`)이 BasePart의 Transparency만 만지고 BillboardGui는 건드리지 않음 → 아치 파트는 투명해져도 라벨은 그대로.
- `AlwaysOnTop=true` + MaxDistance 미설정 → 어디서든 풀사이즈로 보임.
- 라벨 텍스트가 영문 약어 "CP1"/"CP2".

## 수정
- `_setSubVisible`이 `BillboardGui.Enabled` / `SurfaceGui.Enabled` 도 토글.
- 라벨 BillboardGui: 200×60 → 120×32, `AlwaysOnTop` 제거, `MaxDistance=300` 추가.
- 라벨 텍스트: `"CP" .. i` → `"체크포인트 " .. i` (3개 맵 동일).
- 상단 HUD: `"CP1 ☐ CP2 ☐"` → `"1번 ☐ 2번 ☐"`.
- 인트로 배너: `"CP1 → CP2…"` → `"1번 → 2번 체크포인트 아치…"`.
- 통과 토스트: `"CP1 통과! ✓"` → `"체크포인트 1 통과! ✓"`.

## 함께 정리된 미커밋분
- 체크포인트 아치 (글로잉 기둥 + 곡선 상단) — FOREST/OCEAN/SKY 3개 맵.
- RACING 시작 인트로 배너 (2.8초 페이드).
- CP 통과 토스트.
- `RaceIntroShown`, `RaceSeedBroadcast` RemoteEvents + RacingManager 브로드캐스트.
- `_raceSeed` 클라이언트 수신부 (현재는 저장만, 추후 변형용).

## 별개로 조사 필요 (이 PR 범위 밖)
- 스크린샷의 "절대 통과할 수 없는 지점" — 벽/장애물 위치 문제. 어느 바이옴인지/어디인지 확인 후 별도 이슈로.

## Test plan
- [ ] FARMING 페이즈: 체크포인트 라벨/아치 모두 안 보임.
- [ ] RACING 페이즈 시작: 인트로 배너 2.8초 표시 후 페이드, HUD에 "1번 ☐ 2번 ☐" 표시.
- [ ] 아치 통과: 해당 라벨이 ✓로 바뀌고 토스트 표시.
- [ ] 라벨이 멀리(>300 studs)에서는 안 보이고, 가까이서만 보임.
- [ ] 지형/벽 뒤에 있을 땐 라벨이 가려짐 (AlwaysOnTop 제거 효과).

🤖 Generated with [Claude Code](https://claude.com/claude-code)