### PR TITLE
fix: wall +8 extension blocks lanes at sharp kinks (all 3 biomes)

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -317,8 +317,10 @@ local function _buildTrack(root)
 end
 
 -- ─── Continuous track walls (spec §2.4) ───────────────────────────────────────
--- Each segment gets a wall on each side, extended by +4 studs each end so
--- adjacent walls overlap. Two-tone (dark wood + red top-stripe) for visibility.
+-- Walls span exactly segLen. An earlier +8 extension caused the wall from
+-- segment N to jut 4 studs past its endpoint along its own direction at
+-- sharp kinks (S2 arc N4–N6, S4 U-bend N17–N21, S5 chicane N23–N29),
+-- intruding into the next segment's lane.
 
 local function _buildWalls(root)
 	for i = 1, #NODES - 1 do
@@ -327,19 +329,17 @@ local function _buildWalls(root)
 		local cf     = _segCF(a[1], a[2], b[1], b[2])
 
 		for _, side in ipairs({ -1, 1 }) do
-			-- Visible wall body
 			local wall = _part(root, {
 				Name     = "TrackWall",
-				Size     = Vector3.new(2, WALL_H, segLen + 8),
+				Size     = Vector3.new(2, WALL_H, segLen),
 				Color    = C.WALL,
 				Material = MAT.WOOD,
 			})
 			wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H / 2, 0)
 
-			-- Red top-stripe (collidable but visually distinct)
 			local cap = _part(root, {
 				Name     = "TrackWallCap",
-				Size     = Vector3.new(2.4, 0.6, segLen + 8),
+				Size     = Vector3.new(2.4, 0.6, segLen),
 				Color    = C.WALL_TOP,
 				Material = MAT.NEON,
 			})

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -186,16 +186,17 @@ local function _buildReefWalls(root)
 		for _, side in ipairs({ -1, 1 }) do
 			local wall = _part(root, {
 				Name     = "ReefWall",
-				Size     = Vector3.new(3, WALL_H, segLen + 8),  -- +8: adjacent walls overlap at joints
+				-- segLen (no overlap): preserves channel width at sharp kinks (N5/N17/N23).
+				-- An earlier +8 extension intruded 4 studs into the lane at drift-corner apexes.
+				Size     = Vector3.new(3, WALL_H, segLen),
 				Color    = C.REEF,
 				Material = MAT.ROCK,
 			})
 			wall.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), 0, 0)
 
-			-- Red top stripe for visibility
 			local cap = _part(root, {
 				Name     = "ReefWallCap",
-				Size     = Vector3.new(3.4, 0.6, segLen + 8),
+				Size     = Vector3.new(3.4, 0.6, segLen),
 				Color    = C.REEF_TOP,
 				Material = MAT.NEON,
 				CastShadow = false,

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -231,9 +231,12 @@ local function _buildInvisibleWalls(root)
 		if segLen < 0.1 then continue end
 		local cf = _segCF(a[1], a[2], b[1], b[2], (WALL_Y_LO + WALL_Y_HI) / 2)
 		for _, side in ipairs({ -1, 1 }) do
+			-- segLen (no +8): prevents wall protrusion into the next segment's
+			-- corridor at sharp kinks. Floor still uses +8 for joint coverage
+			-- since players drive ON it laterally.
 			local wall = _part(root, {
 				Name = "InvisibleWall_" .. i .. (side > 0 and "R" or "L"),
-				Size = Vector3.new(2, wallH, segLen + 8),
+				Size = Vector3.new(2, wallH, segLen),
 				CanCollide = true, Transparency = 1, CastShadow = false,
 			})
 			wall.CFrame = cf * CFrame.new(side * (CORRIDOR_W / 2 + 1), 0, 0)


### PR DESCRIPTION
## Summary

- **Bug**: Reef walls (Ocean), TrackWalls (Forest), and InvisibleWalls (Sky) were sized `segLen + 8`. At sharp kinks the wall extends 4 studs past the endpoint *along its own segment direction*, intruding into the next segment's lane.
- **Symptom (user-reported, OCEAN)**: cyan WakeRing zones at the three drift-corner apexes (N5, N17, N23) appear "impassable" — players bump the reef wall protrusion right beside the non-collidable WakeRing and blame the ring.
- **Fix**: Walls now use `segLen` so adjacent walls meet at the endpoint without bleeding into the next segment. Floor / lane stripes / track surface keep their `+4`/`+8` extension (players drive ON them — joint coverage is fine, not a blocker).

Same fix applied to Forest (S2 arc N4–N6, S4 U-bend N17–N21, S5 chicane N23–N29) and Sky (figure-8 loop apexes and S5 zigzag) since they share the bug.

## Test plan

- [ ] Ocean: drive a full lap; confirm the three drift-corner apexes are passable (cyan WakeRing no longer blocks).
- [ ] Forest: confirm S2 outcrop hairpin, S4 U-bend peak (N19), and S5 S-chicane are passable.
- [ ] Sky: confirm Loop A apex (N10), Loop B apex (N16), and S5 zigzag (N23–N29) are passable.
- [ ] Visual: hairline seams may appear at concave inner corners (rock material, < 2 studs). Confirm no obvious gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)