### PR TITLE
fix(ocean): palm island top uses sand, not grass

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -252,10 +252,14 @@ local function _buildPalmIsland(root)
 		Position = Vector3.new(cx, WATER_Y - 2, cz),
 		Color = C.SAND, Material = MAT.SAND,
 	})
+	-- Beach surface (sand, not grass): ocean biome shouldn't look like farmland,
+	-- and Material.Grass renders blades that persisted even with low transparency.
+	-- Slightly lighter sand differentiates the dry top from the sand base.
 	_part(root, {
-		Name = "Palm_IslandGrass", Size = Vector3.new(95, 1.5, 200),
+		Name = "Palm_IslandTop", Size = Vector3.new(95, 1.5, 200),
 		Position = Vector3.new(cx, WATER_Y + 2.5, cz),
-		Color = C.GRASS, Material = MAT.GRASS,
+		Color = Color3.fromRGB(235, 210, 150),
+		Material = MAT.SAND,
 	})
 
 	local rng = Random.new(99)


### PR DESCRIPTION
## Summary

User-reported screenshot showed the OCEAN biome's S2 arc center looking like a green farmland with tall grass blades poking out of cyan water — not like ocean. Two compounding causes:

1. `Palm_IslandGrass` used `Material.Grass`, which renders 3D grass blades. Roblox renders those blades regardless of low `Transparency` values, so they're visually loud.
2. The green color (`C.GRASS = rgb(80,160,70)`) reinforces the farmland look.

There's also a likely gameplay side effect: when a vehicle drifts onto the grass, `Material.Grass` has high friction → vehicle stalls (`Speed = 0` with up arrow held). Sand is much smoother, so vehicles can recover.

## Change

`Palm_IslandGrass` → `Palm_IslandTop`, `Material.Grass` → `Material.Sand`, color → light beach sand. Size and position unchanged (the island still anchors the S2 arc and blocks the straight-line shortcut).

## Test plan

- [ ] In Studio, restart Play session so OceanMapBuilder runs fresh.
- [ ] Confirm the S2 arc interior reads as a sandy beach, not grass blades.
- [ ] Verify the island still blocks a centerline shortcut (CanCollide preserved).
- [ ] If a vehicle ends up on the island, confirm it can recover off the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)