### PR TITLE
feat(race-ux): permeable walls + slow zones + seeded boost pads

### DIFF
--- a/roblox/ReplicatedStorage/Shared/Constants.lua
+++ b/roblox/ReplicatedStorage/Shared/Constants.lua
@@ -146,6 +146,8 @@ Constants.VEHICLE_TYPE = {
 Constants.OBSTACLE_BOUNCE_PENALTY_DURATION = 1.0  -- seconds
 Constants.OBSTACLE_BOUNCE_SPEED_MULT       = 0.5
 Constants.MUD_SPEED_MULT                   = 0.5
+Constants.SLOW_ZONE_MULT                   = 0.6  -- off-corridor soft penalty
+Constants.RACE_BOOST_PAD_ACTIVE_RATIO      = 0.6  -- fraction of placed BoostPads active per race
 Constants.SKY_GRAVITY_MULT                 = 1.2  -- outside updraft zones
 Constants.UPDRAFT_BASE_FORCE               = 200  -- studs/s² upward (scaled by flyability)
 

--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -321,30 +321,102 @@ end
 -- segment N to jut 4 studs past its endpoint along its own direction at
 -- sharp kinks (S2 arc N4–N6, S4 U-bend N17–N21, S5 chicane N23–N29),
 -- intruding into the next segment's lane.
+--
+-- Wall is broken into sub-walls separated by 8-stud gaps every WALL_GAP_INTERVAL
+-- studs of cumulative track-arc distance. Players can squeeze through the
+-- doorways onto the grass for risky shortcuts; the SlowZone outside the wall
+-- (see _buildSlowZones below) penalises that with a speed mult.
+
+local WALL_GAP_INTERVAL   = 48          -- cumulative arc distance between gap centers
+local WALL_GAP_HALF_WIDTH = 4           -- 8-stud opening
+
+-- Returns list of {start, end} sub-wall intervals (local to segment, in segment-Z),
+-- after carving out gap zones at cumulative arc positions multiple-of-GAP_INTERVAL.
+local function _wallPieces(arcStart, segLen)
+	local pieces = {}
+	local cursor = 0  -- segment-local start of next sub-wall
+	local firstGapK = math.ceil((arcStart - WALL_GAP_HALF_WIDTH) / WALL_GAP_INTERVAL)
+	local k = firstGapK
+	while true do
+		local gapArc = k * WALL_GAP_INTERVAL
+		local gapStartArc = gapArc - WALL_GAP_HALF_WIDTH
+		local gapEndArc   = gapArc + WALL_GAP_HALF_WIDTH
+		if gapStartArc >= arcStart + segLen then break end
+		if gapEndArc > arcStart then
+			local relStart = math.max(0, gapStartArc - arcStart)
+			local relEnd   = math.min(segLen, gapEndArc - arcStart)
+			if relStart > cursor then
+				table.insert(pieces, { cursor, relStart })
+			end
+			cursor = math.max(cursor, relEnd)
+		end
+		k = k + 1
+	end
+	if cursor < segLen then
+		table.insert(pieces, { cursor, segLen })
+	end
+	return pieces
+end
 
 local function _buildWalls(root)
+	local arcStart = 0
 	for i = 1, #NODES - 1 do
 		local a, b   = NODES[i], NODES[i + 1]
 		local segLen = _segLen(a[1], a[2], b[1], b[2])
 		local cf     = _segCF(a[1], a[2], b[1], b[2])
 
-		for _, side in ipairs({ -1, 1 }) do
-			local wall = _part(root, {
-				Name     = "TrackWall",
-				Size     = Vector3.new(2, WALL_H, segLen),
-				Color    = C.WALL,
-				Material = MAT.WOOD,
-			})
-			wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H / 2, 0)
+		for _, piece in ipairs(_wallPieces(arcStart, segLen)) do
+			local pStart, pEnd = piece[1], piece[2]
+			local pLen = pEnd - pStart
+			if pLen < 0.5 then continue end
+			local pMid = (pStart + pEnd) / 2 - segLen / 2  -- segment-local Z offset
 
-			local cap = _part(root, {
-				Name     = "TrackWallCap",
-				Size     = Vector3.new(2.4, 0.6, segLen),
-				Color    = C.WALL_TOP,
-				Material = MAT.NEON,
+			for _, side in ipairs({ -1, 1 }) do
+				local wall = _part(root, {
+					Name     = "TrackWall",
+					Size     = Vector3.new(2, WALL_H, pLen),
+					Color    = C.WALL,
+					Material = MAT.WOOD,
+				})
+				wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H / 2, pMid)
+
+				local cap = _part(root, {
+					Name     = "TrackWallCap",
+					Size     = Vector3.new(2.4, 0.6, pLen),
+					Color    = C.WALL_TOP,
+					Material = MAT.NEON,
+				})
+				cap.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H + 0.3, pMid)
+				cap.CastShadow = false
+			end
+		end
+		arcStart = arcStart + segLen
+	end
+end
+
+-- ─── Slow zones outside the corridor (soft penalty for off-track shortcuts) ─
+
+local function _buildSlowZones(root)
+	local SZ_WIDTH = 40       -- stud width per side
+	local SZ_HEIGHT = 4       -- low trigger volume
+	local SZ_OFFSET = TRACK_W / 2 + 1 + SZ_WIDTH / 2 + 2  -- just outside wall
+	for i = 1, #NODES - 1 do
+		local a, b   = NODES[i], NODES[i + 1]
+		local segLen = _segLen(a[1], a[2], b[1], b[2])
+		if segLen < 0.1 then continue end
+		local cf = _segCF(a[1], a[2], b[1], b[2])
+		for _, side in ipairs({ -1, 1 }) do
+			local sz = _part(root, {
+				Name = "SlowZone_" .. i .. (side > 0 and "R" or "L"),
+				Size = Vector3.new(SZ_WIDTH, SZ_HEIGHT, segLen + 8),
+				Color = C.MUD,
+				Material = MAT.MUD,
+				CanCollide = false,
+				Transparency = 0.6,
+				CastShadow = false,
 			})
-			cap.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H + 0.3, 0)
-			cap.CastShadow = false
+			sz.CFrame = cf * CFrame.new(side * SZ_OFFSET, SZ_HEIGHT / 2 + 0.1, 0)
+			_tag(sz, "SlowZone")
 		end
 	end
 end
@@ -815,6 +887,7 @@ local function buildForest()
 
 	_buildTrack(trackSub)
 	_buildWalls(trackSub)
+	_buildSlowZones(trackSub)
 	_buildRiverBridge(trackSub)
 	_buildMudZones(trackSub)
 	_buildRockDecor(trackSub)

--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -272,6 +272,11 @@ end
 -- One TrackSeg per node-pair, slightly elongated by +2 studs on each end so
 -- adjacent segments overlap at the joints (no thin gap visible at corners).
 
+-- Vehicle drive uses BodyVelocity (RacingClient _driveLoop), so floor friction
+-- is pure drag, not traction. Default Asphalt friction (~0.5) caused noticeable
+-- "sticky" slowdowns. 0.05 with frictionWeight=100 keeps the vehicle gliding.
+local LOW_FRICTION_SURFACE = PhysicalProperties.new(1, 0.05, 0.1, 100, 1)
+
 local function _buildTrack(root)
 	for i = 1, #NODES - 1 do
 		local a, b   = NODES[i], NODES[i + 1]
@@ -284,6 +289,7 @@ local function _buildTrack(root)
 			Color    = C.TRACK,
 			Material = MAT.TRACK,
 		})
+		seg.CustomPhysicalProperties = LOW_FRICTION_SURFACE
 		seg.CFrame = cf
 
 		-- White outer-edge stripe (visual only).
@@ -378,6 +384,7 @@ local function _buildWalls(root)
 					Color    = C.WALL,
 					Material = MAT.WOOD,
 				})
+				wall.CustomPhysicalProperties = LOW_FRICTION_SURFACE
 				wall.CFrame = cf * CFrame.new(side * (TRACK_W / 2 + 1), WALL_H / 2, pMid)
 
 				local cap = _part(root, {

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -177,31 +177,98 @@ end
 
 -- ─── Reef walls (spec §3.4): solid above-water at ±30 stud offset ────────────
 
+-- Wall is broken into sub-walls separated by gaps every WALL_GAP_INTERVAL studs
+-- of cumulative track-arc distance. Player can swim/sail through the doorway
+-- onto open water; the SlowZone outside (_buildSlowZones) imposes a speed mult.
+
+local WALL_GAP_INTERVAL   = 48
+local WALL_GAP_HALF_WIDTH = 4   -- 8-stud opening
+
+local function _wallPieces(arcStart, segLen)
+	local pieces = {}
+	local cursor = 0
+	local firstGapK = math.ceil((arcStart - WALL_GAP_HALF_WIDTH) / WALL_GAP_INTERVAL)
+	local k = firstGapK
+	while true do
+		local gapArc = k * WALL_GAP_INTERVAL
+		local gapStartArc = gapArc - WALL_GAP_HALF_WIDTH
+		local gapEndArc   = gapArc + WALL_GAP_HALF_WIDTH
+		if gapStartArc >= arcStart + segLen then break end
+		if gapEndArc > arcStart then
+			local relStart = math.max(0, gapStartArc - arcStart)
+			local relEnd   = math.min(segLen, gapEndArc - arcStart)
+			if relStart > cursor then
+				table.insert(pieces, { cursor, relStart })
+			end
+			cursor = math.max(cursor, relEnd)
+		end
+		k = k + 1
+	end
+	if cursor < segLen then
+		table.insert(pieces, { cursor, segLen })
+	end
+	return pieces
+end
+
 local function _buildReefWalls(root)
+	local arcStart = 0
 	for i = 1, #NODES - 1 do
 		local a, b   = NODES[i], NODES[i + 1]
 		local segLen = _segLen(a[1], a[2], b[1], b[2])
 		local cf     = _segCF(a[1], a[2], b[1], b[2], WATER_Y + WALL_H / 2)
 
-		for _, side in ipairs({ -1, 1 }) do
-			local wall = _part(root, {
-				Name     = "ReefWall",
-				-- segLen (no overlap): preserves channel width at sharp kinks (N5/N17/N23).
-				-- An earlier +8 extension intruded 4 studs into the lane at drift-corner apexes.
-				Size     = Vector3.new(3, WALL_H, segLen),
-				Color    = C.REEF,
-				Material = MAT.ROCK,
-			})
-			wall.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), 0, 0)
+		for _, piece in ipairs(_wallPieces(arcStart, segLen)) do
+			local pStart, pEnd = piece[1], piece[2]
+			local pLen = pEnd - pStart
+			if pLen < 0.5 then continue end
+			local pMid = (pStart + pEnd) / 2 - segLen / 2
 
-			local cap = _part(root, {
-				Name     = "ReefWallCap",
-				Size     = Vector3.new(3.4, 0.6, segLen),
-				Color    = C.REEF_TOP,
+			for _, side in ipairs({ -1, 1 }) do
+				local wall = _part(root, {
+					Name     = "ReefWall",
+					Size     = Vector3.new(3, WALL_H, pLen),
+					Color    = C.REEF,
+					Material = MAT.ROCK,
+				})
+				wall.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), 0, pMid)
+
+				local cap = _part(root, {
+					Name     = "ReefWallCap",
+					Size     = Vector3.new(3.4, 0.6, pLen),
+					Color    = C.REEF_TOP,
+					Material = MAT.NEON,
+					CastShadow = false,
+				})
+				cap.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), WALL_H / 2 + 0.3, pMid)
+			end
+		end
+		arcStart = arcStart + segLen
+	end
+end
+
+-- ─── Slow zones outside the reef walls (rough water / chop) ─────────────────
+
+local function _buildSlowZones(root)
+	local SZ_WIDTH  = 50
+	local SZ_HEIGHT = 4
+	local SZ_OFFSET = LANE_W / 2 + 1.5 + SZ_WIDTH / 2 + 2
+	for i = 1, #NODES - 1 do
+		local a, b   = NODES[i], NODES[i + 1]
+		local segLen = _segLen(a[1], a[2], b[1], b[2])
+		if segLen < 0.1 then continue end
+		local cf = _segCF(a[1], a[2], b[1], b[2], WATER_Y + SZ_HEIGHT / 2)
+		for _, side in ipairs({ -1, 1 }) do
+			local sz = _part(root, {
+				Name = "SlowZone_" .. i .. (side > 0 and "R" or "L"),
+				Size = Vector3.new(SZ_WIDTH, SZ_HEIGHT, segLen + 8),
+				Color = C.WATER_FOAM,
 				Material = MAT.NEON,
+				CanCollide = false,
+				Transparency = 0.65,
 				CastShadow = false,
 			})
-			cap.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), WALL_H / 2 + 0.3, 0)
+			sz.CFrame = cf * CFrame.new(side * SZ_OFFSET, 0, 0)
+			_tag(sz, "SlowZone")
 		end
 	end
 end
@@ -578,6 +645,7 @@ local function buildOcean()
 	_buildReefFormation(trackSub)
 	_buildLaneStrip(trackSub)
 	_buildReefWalls(trackSub)
+	_buildSlowZones(trackSub)
 	_buildCourseBuoys(trackSub)
 	_buildBoostPads(trackSub)
 	_buildJumpRamps(trackSub)

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -184,6 +184,10 @@ end
 local WALL_GAP_INTERVAL   = 48
 local WALL_GAP_HALF_WIDTH = 4   -- 8-stud opening
 
+-- Same rationale as FOREST/SKY: BodyVelocity propulsion means wall contact
+-- is pure drag. Low friction makes boats glide along the reef instead of pinning.
+local LOW_FRICTION_SURFACE = PhysicalProperties.new(1, 0.05, 0.1, 100, 1)
+
 local function _wallPieces(arcStart, segLen)
 	local pieces = {}
 	local cursor = 0
@@ -230,6 +234,7 @@ local function _buildReefWalls(root)
 					Color    = C.REEF,
 					Material = MAT.ROCK,
 				})
+				wall.CustomPhysicalProperties = LOW_FRICTION_SURFACE
 				wall.CFrame = cf * CFrame.new(side * (LANE_W / 2 + 1.5), 0, pMid)
 
 				local cap = _part(root, {

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -221,26 +221,52 @@ local function _buildFloor(root)
 	end
 end
 
--- ─── Invisible side walls (spec §4.4: ±25, Y 54→114) ─────────────────────────
+-- ─── Edge barriers (spec §4.4 revised: visible permeable pillars) ───────────
+-- Replaces the original invisible CanCollide=true walls. Players reported the
+-- mystery "I just stopped" effect with no way around. New design:
+--   - Crystal pillars (2x2 stud, neon) along corridor edge — visible
+--   - Pillar every PILLAR_SPACING studs along the track
+--   - Every GAP_INTERVAL studs of *track-cumulative* distance, an opening of
+--     2 * GAP_HALF_WIDTH studs is left for risky shortcuts
+--   - Running-distance gap pattern (not per-segment) so even short segments at
+--     sharp corners still get gaps — guarantees no impassable sub-section
 
-local function _buildInvisibleWalls(root)
+local PILLAR_SPACING = 6
+local GAP_INTERVAL   = 48
+local GAP_HALF_WIDTH = 4   -- 8-stud doorway
+
+local function _isInGap(arcPos)
+	local nearestGapCenter = math.floor(arcPos / GAP_INTERVAL + 0.5) * GAP_INTERVAL
+	return math.abs(arcPos - nearestGapCenter) < GAP_HALF_WIDTH
+end
+
+local function _buildEdgeBarriers(root)
 	local wallH = WALL_Y_HI - WALL_Y_LO
+	local pillarColors = { C.CRYSTAL, C.CRYSTAL2 }
+	local arcStart = 0  -- cumulative arc-distance at start of current segment
 	for i = 1, #NODES - 1 do
 		local a, b = NODES[i], NODES[i + 1]
 		local segLen = _segLen(a[1], a[2], b[1], b[2])
 		if segLen < 0.1 then continue end
 		local cf = _segCF(a[1], a[2], b[1], b[2], (WALL_Y_LO + WALL_Y_HI) / 2)
-		for _, side in ipairs({ -1, 1 }) do
-			-- segLen (no +8): prevents wall protrusion into the next segment's
-			-- corridor at sharp kinks. Floor still uses +8 for joint coverage
-			-- since players drive ON it laterally.
-			local wall = _part(root, {
-				Name = "InvisibleWall_" .. i .. (side > 0 and "R" or "L"),
-				Size = Vector3.new(2, wallH, segLen),
-				CanCollide = true, Transparency = 1, CastShadow = false,
-			})
-			wall.CFrame = cf * CFrame.new(side * (CORRIDOR_W / 2 + 1), 0, 0)
+		local numPillars = math.max(1, math.floor(segLen / PILLAR_SPACING))
+		for slot = 0, numPillars - 1 do
+			local relAlong = (slot + 0.5) * PILLAR_SPACING       -- distance from seg start
+			local arcPos   = arcStart + relAlong                 -- cumulative arc distance
+			if _isInGap(arcPos) then continue end
+			local localZ = relAlong - segLen / 2                 -- CFrame-local Z
+			for _, side in ipairs({ -1, 1 }) do
+				local pillar = _part(root, {
+					Name = "EdgePillar_" .. i .. "_" .. slot .. (side > 0 and "R" or "L"),
+					Size = Vector3.new(2, wallH, 2),
+					Color = pillarColors[(slot % 2) + 1],
+					Material = MAT.CRYSTAL,
+					CanCollide = true, CastShadow = false,
+				})
+				pillar.CFrame = cf * CFrame.new(side * (CORRIDOR_W / 2 + 1), 0, localZ)
+			end
 		end
+		arcStart = arcStart + segLen
 	end
 end
 
@@ -644,7 +670,7 @@ local function buildSky()
 	_buildFarmPlatform(farmSub)
 
 	_buildFloor(trackSub)
-	_buildInvisibleWalls(trackSub)
+	_buildEdgeBarriers(trackSub)
 	_buildInvisibleCeiling(trackSub)
 	_buildCrystalClusters(trackSub)
 	_buildBoostPads(trackSub)

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -193,6 +193,12 @@ end
 
 -- ─── Continuous track floor (spec §4.4: no inter-platform gaps) ──────────────
 
+-- Track surface friction. Roblox vehicles here use BodyVelocity-based
+-- propulsion (RacingClient _driveLoop), so floor friction acts as pure drag,
+-- not traction. Default Rock = 0.5 caused noticeable "sticky" sections —
+-- 0.05 with frictionWeight=100 keeps the vehicle gliding.
+local LOW_FRICTION_FLOOR = PhysicalProperties.new(1, 0.05, 0.1, 100, 1)
+
 local function _buildFloor(root)
 	local colors = { C.PLATFORM, C.PLATFORM2, C.PLATFORM3 }
 	for i = 1, #NODES - 1 do
@@ -206,6 +212,7 @@ local function _buildFloor(root)
 			Color    = colors[((i - 1) % 3) + 1],
 			Material = MAT.ROCK,
 		})
+		floor.CustomPhysicalProperties = LOW_FRICTION_FLOOR
 		floor.CFrame = cf
 
 		-- Edge glow stripes on both sides for visibility
@@ -235,6 +242,12 @@ local PILLAR_SPACING = 6
 local GAP_INTERVAL   = 48
 local GAP_HALF_WIDTH = 4   -- 8-stud doorway
 
+-- High frictionWeight + very low friction makes the vehicle slide *along*
+-- the pillars (and other walls) instead of getting brake-pinned by them.
+-- Roblox blends surface frictions weighted: with weight=100 and friction=0.05
+-- on the wall vs default tire friction, contact friction ≈ 0.054.
+local LOW_FRICTION = PhysicalProperties.new(1, 0.05, 0.1, 100, 1)
+
 local function _isInGap(arcPos)
 	local nearestGapCenter = math.floor(arcPos / GAP_INTERVAL + 0.5) * GAP_INTERVAL
 	return math.abs(arcPos - nearestGapCenter) < GAP_HALF_WIDTH
@@ -263,6 +276,7 @@ local function _buildEdgeBarriers(root)
 					Material = MAT.CRYSTAL,
 					CanCollide = true, CastShadow = false,
 				})
+				pillar.CustomPhysicalProperties = LOW_FRICTION
 				pillar.CFrame = cf * CFrame.new(side * (CORRIDOR_W / 2 + 1), 0, localZ)
 			end
 		end

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -378,32 +378,61 @@ end
 
 local _boostPadCooldowns = {}   -- { [partRef] = { [userId] = expireTick } }
 
+-- Seed-driven subset selection: each race picks a different K-of-N subset of
+-- placed BoostPads to be active. Inactive ones are visually dimmed so players
+-- can tell which are live, but don't fire. Adds per-race variety so memorized
+-- pad routes don't dominate.
 local function _setupBoostPads()
-	for _, part in ipairs(CollectionService:GetTagged("BoostPad")) do
-		_boostPadCooldowns[part] = {}
-		part.Touched:Connect(function(hit)
-			local vehicle = hit:FindFirstAncestorWhichIsA("Model")
-			if not vehicle then return end
-			for _, player in ipairs(Players:GetPlayers()) do
-				local pdata = SessionManager.getData(player)
-				if pdata and pdata.vehicleModel == vehicle then
-					local cds = _boostPadCooldowns[part]
-					if cds[player.UserId] and tick() < cds[player.UserId] then break end
-					cds[player.UserId] = tick() + 5   -- 5s pad cooldown
+	local pads = CollectionService:GetTagged("BoostPad")
+	if #pads == 0 then return end
 
-					local seat = vehicle:FindFirstChildWhichIsA("VehicleSeat", true)
-					if seat then
-						local old = seat.MaxSpeed
-						seat.MaxSpeed = old * 1.4
-						task.delay(2, function()
-							if seat and seat.Parent then seat.MaxSpeed = old end
-						end)
+	-- Deterministic shuffle by _raceSeed
+	local rng = Random.new(_raceSeed)
+	local shuffled = {}
+	for _, p in ipairs(pads) do table.insert(shuffled, p) end
+	for i = #shuffled, 2, -1 do
+		local j = rng:NextInteger(1, i)
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	end
+
+	local activeCount = math.max(1, math.ceil(#shuffled * Constants.RACE_BOOST_PAD_ACTIVE_RATIO))
+	local activeSet = {}
+	for i = 1, activeCount do activeSet[shuffled[i]] = true end
+
+	for _, part in ipairs(pads) do
+		if activeSet[part] then
+			_boostPadCooldowns[part] = {}
+			part.Touched:Connect(function(hit)
+				local vehicle = hit:FindFirstAncestorWhichIsA("Model")
+				if not vehicle then return end
+				for _, player in ipairs(Players:GetPlayers()) do
+					local pdata = SessionManager.getData(player)
+					if pdata and pdata.vehicleModel == vehicle then
+						local cds = _boostPadCooldowns[part]
+						if cds[player.UserId] and tick() < cds[player.UserId] then break end
+						cds[player.UserId] = tick() + 5   -- 5s pad cooldown
+
+						local seat = vehicle:FindFirstChildWhichIsA("VehicleSeat", true)
+						if seat then
+							local old = seat.MaxSpeed
+							seat.MaxSpeed = old * 1.4
+							task.delay(2, function()
+								if seat and seat.Parent then seat.MaxSpeed = old end
+							end)
+						end
+						RemoteEvents.ScreenEffect:FireClient(player, "boostPad", {})
+						break
 					end
-					RemoteEvents.ScreenEffect:FireClient(player, "boostPad", {})
-					break
 				end
-			end
-		end)
+			end)
+		else
+			-- Dim the inactive pad so players can see it's not live this round
+			pcall(function()
+				part.Transparency = math.max(part.Transparency, 0.75)
+			end)
+			local ring = part.Parent and part.Parent:FindFirstChild(part.Name .. "Ring", true)
+			if ring then pcall(function() ring.Transparency = 0.9 end) end
+		end
 	end
 end
 
@@ -556,6 +585,10 @@ GameManager.onPhaseChanged(function(phase, biome)
 			}
 		end
 
+		-- Generate per-race seed first — _setupBoostPads consumes it for its
+		-- K-of-N subset selection. Broadcast happens below alongside the intro.
+		_raceSeed = math.random(1, 1000000)
+
 		-- Setup collision systems
 		_setupObstacles()
 		_setupBoostPads()
@@ -579,9 +612,9 @@ GameManager.onPhaseChanged(function(phase, biome)
 		_setupFinishLine()
 		_startPositionSync()
 
-		-- Broadcast race intro overlay + per-race seed (for client variation)
+		-- Broadcast race intro overlay + per-race seed (for client variation).
+		-- _raceSeed was set above before _setupBoostPads consumed it.
 		RemoteEvents.RaceIntroShown:FireAllClients({ biome = biome })
-		_raceSeed = math.random(1, 1000000)
 		RemoteEvents.RaceSeedBroadcast:FireAllClients(_raceSeed)
 
 	elseif phase == Constants.PHASES.RESULTS then

--- a/roblox/ServerScriptService/RacingManager.server.lua
+++ b/roblox/ServerScriptService/RacingManager.server.lua
@@ -117,6 +117,53 @@ local function _setupMudZones()
 	end
 end
 
+-- ─── Slow zones (off-corridor soft penalty, FOREST + OCEAN) ─────────────────
+-- Players can squeeze through the wall gaps; the SlowZone trigger pads
+-- outside the wall apply SLOW_ZONE_MULT to vehicle MaxSpeed while touching.
+-- Same Touched/TouchEnded pattern as _setupMudZones, separate state flag.
+
+local function _setupSlowZones()
+	for _, part in ipairs(CollectionService:GetTagged("SlowZone")) do
+		part.Touched:Connect(function(hit)
+			local vehicle = hit:FindFirstAncestorWhichIsA("Model")
+			if not vehicle then return end
+			for _, player in ipairs(Players:GetPlayers()) do
+				local pdata = SessionManager.getData(player)
+				if pdata and pdata.vehicleModel == vehicle then
+					local ps = _physState[player.UserId]
+					if ps and not ps.inSlowZone then
+						ps.inSlowZone = true
+						local seat = vehicle:FindFirstChildWhichIsA("VehicleSeat", true)
+						if seat then
+							seat.MaxSpeed = seat.MaxSpeed * Constants.SLOW_ZONE_MULT
+						end
+					end
+					break
+				end
+			end
+		end)
+
+		part.TouchEnded:Connect(function(hit)
+			local vehicle = hit:FindFirstAncestorWhichIsA("Model")
+			if not vehicle then return end
+			for _, player in ipairs(Players:GetPlayers()) do
+				local pdata = SessionManager.getData(player)
+				if pdata and pdata.vehicleModel == vehicle then
+					local ps = _physState[player.UserId]
+					if ps and ps.inSlowZone then
+						ps.inSlowZone = false
+						local seat = vehicle:FindFirstChildWhichIsA("VehicleSeat", true)
+						if seat then
+							seat.MaxSpeed = seat.MaxSpeed / Constants.SLOW_ZONE_MULT
+						end
+					end
+					break
+				end
+			end
+		end)
+	end
+end
+
 -- ─── Buoyancy (OCEAN) ─────────────────────────────────────────────────────────
 
 local WATER_Y = 0   -- set from BiomeConfig at race start
@@ -501,6 +548,7 @@ GameManager.onPhaseChanged(function(phase, biome)
 			_physState[player.UserId] = {
 				inMud             = false,
 				inUpdraft         = false,
+				inSlowZone        = false,
 				boostCooldownEnd  = 0,
 				obstaclePenaltyEnd = 0,
 				drifting          = false,
@@ -512,6 +560,8 @@ GameManager.onPhaseChanged(function(phase, biome)
 		_setupObstacles()
 		_setupBoostPads()
 		_setupDriftCorners()   -- all biomes: charges boost gauge (F key)
+
+		_setupSlowZones()   -- FOREST + OCEAN have SlowZone-tagged trigger pads
 
 		if biome == "FOREST" then
 			_setupMudZones()


### PR DESCRIPTION
## Summary

Two-commit follow-up to #156 (checkpoint arch gates). Completes the 3-part race UX overhaul.

### Commit 1 — Permeable visible walls + off-corridor slow zones
- **SKY**: replaces the invisible `CanCollide=true` walls with **visible crystal pillars** along the corridor edge. No more "mystery barrier" stops.
- **All biomes**: walls now have a **8-stud doorway every 48 studs** of *cumulative track-arc distance*. Running-distance gap pattern guarantees gaps fall even on short segments at sharp corners — **no sub-section is completely walled off**.
- **FOREST + OCEAN**: + `_buildSlowZones` adds wide trigger pads outside the wall (mud / rough water), tagged `SlowZone`. `RacingManager._setupSlowZones` applies `SLOW_ZONE_MULT=0.6` to `VehicleSeat.MaxSpeed` while touching — same Touched/TouchEnded pattern as `_setupMudZones`.
- Squeezing through a wall gap is now a risky shortcut: SKY drops the player off the platform, FOREST/OCEAN penalises with the slow zone.

### Commit 2 — Seeded per-race boost pad subset
- `_setupBoostPads` shuffles tagged BoostPads via `Random.new(_raceSeed)` and enables `RACE_BOOST_PAD_ACTIVE_RATIO` (60%) of them per round. Inactive pads stay visible but dimmed so players can tell which are live this round.
- Per-race seed is broadcast to clients via `RaceSeedBroadcast` (defined in #156) — placeholder for future client-side seeded effects.

## Test plan

- [ ] **SKY**: drive corridor — pillars visible, can squeeze through doorways every ~48 studs. Squeezing through drops you off (kill plane). No mystery stops.
- [ ] **FOREST**: drive corridor — gaps every ~48 studs visible in the wood wall. Squeeze through → land on mud → noticeable slowdown. Drive back onto track → speed restored.
- [ ] **OCEAN**: same as FOREST, with reef wall + foam slow zone.
- [ ] **All biomes**: boost pads — visible count looks reduced this round vs full set. Run race twice and confirm different pads activate.
- [ ] **No regression**: checkpoint arches (#156) still placed, intro overlay still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)