### PR TITLE
fix(checkpoint+ui): walk up Model ancestors + English CP labels

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/ForestMapBuilder.server.lua
@@ -680,7 +680,7 @@ local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
 	local lbl = Instance.new("TextLabel")
 	lbl.Size = UDim2.fromScale(1, 1)
 	lbl.BackgroundTransparency = 1
-	lbl.Text = "체크포인트 " .. cpIndex
+	lbl.Text = "CP " .. cpIndex
 	lbl.TextColor3 = archColor
 	lbl.TextStrokeColor3 = Color3.new(0, 0, 0)
 	lbl.TextStrokeTransparency = 0.2

--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -499,7 +499,7 @@ local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
 	local lbl = Instance.new("TextLabel")
 	lbl.Size = UDim2.fromScale(1, 1)
 	lbl.BackgroundTransparency = 1
-	lbl.Text = "체크포인트 " .. cpIndex
+	lbl.Text = "CP " .. cpIndex
 	lbl.TextColor3 = archColor
 	lbl.TextStrokeColor3 = Color3.new(0, 0, 0)
 	lbl.TextStrokeTransparency = 0.2

--- a/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/SkyMapBuilder.server.lua
@@ -550,7 +550,7 @@ local function _buildCheckpointGate(root, x, z, cpIndex, archColor)
 	local lbl = Instance.new("TextLabel")
 	lbl.Size                   = UDim2.fromScale(1, 1)
 	lbl.BackgroundTransparency = 1
-	lbl.Text                   = "체크포인트 " .. cpIndex
+	lbl.Text                   = "CP " .. cpIndex
 	lbl.TextColor3             = archColor
 	lbl.TextStrokeColor3       = Color3.new(0, 0, 0)
 	lbl.TextStrokeTransparency = 0.2

--- a/roblox/ServerScriptService/Modules/CheckpointService.lua
+++ b/roblox/ServerScriptService/Modules/CheckpointService.lua
@@ -30,21 +30,31 @@ local function _ensure(userId)
 	return _state[userId]
 end
 
-local function _findPlayerByVehicle(vehicle)
-	for _, player in ipairs(Players:GetPlayers()) do
-		local pdata = SessionManager.getData(player)
-		if pdata and pdata.vehicleModel == vehicle then
-			return player
+-- BODY-driven chassis (#139) and other slot items mount the item's FBX model
+-- inside the vehicle Model. FindFirstAncestorWhichIsA("Model") on the touched
+-- part can stop at the BODY sub-model instead of the registered vehicle Model.
+-- Walk up ALL Model ancestors and check each against every player's
+-- vehicleModel so the comparison succeeds wherever the contact part lives.
+local function _findPlayerByTouch(hit)
+	local players = Players:GetPlayers()
+	local vehicleByModel = {}
+	for _, p in ipairs(players) do
+		local pdata = SessionManager.getData(p)
+		if pdata and pdata.vehicleModel then
+			vehicleByModel[pdata.vehicleModel] = p
 		end
+	end
+	local node = hit
+	while node do
+		if vehicleByModel[node] then return vehicleByModel[node] end
+		node = node.Parent
 	end
 	return nil
 end
 
 local function _connectCheckpoint(part, cpIndex)
 	return part.Touched:Connect(function(hit)
-		local vehicle = hit:FindFirstAncestorWhichIsA("Model")
-		if not vehicle then return end
-		local player = _findPlayerByVehicle(vehicle)
+		local player = _findPlayerByTouch(hit)
 		if not player then return end
 
 		local s = _ensure(player.UserId)

--- a/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
+++ b/roblox/StarterPlayer/StarterPlayerScripts/RacingClient.client.lua
@@ -413,7 +413,7 @@ local function _showCheckpointPassToast(cpIndex)
 		lbl.TextStrokeTransparency = 0.3
 		lbl.Parent                 = overlay
 	end
-	lbl.Text             = "체크포인트 " .. cpIndex .. " 통과! ✓"
+	lbl.Text             = "CP " .. cpIndex .. " PASSED ✓"
 	lbl.TextColor3       = CP_PASSED_COLOR
 	lbl.TextTransparency = 0
 	TweenService:Create(lbl, TweenInfo.new(1.2, Enum.EasingStyle.Quad), {
@@ -470,7 +470,7 @@ local function _showRaceIntro()
 	body.Size                    = UDim2.new(1, -20, 0, 44)
 	body.Position                = UDim2.new(0, 10, 0, 46)
 	body.BackgroundTransparency  = 1
-	body.Text                    = "1번 → 2번 체크포인트 아치를 순서대로 통과한 뒤 결승선!"
+	body.Text                    = "Drive through CP 1 → CP 2 → Finish!"
 	body.TextColor3              = Color3.fromRGB(220, 230, 245)
 	body.Font                    = Enum.Font.GothamBold
 	body.TextScaled              = true


### PR DESCRIPTION
## Summary

Two playtest feedback fixes bundled.

### Bug — CP pass not registering after #156

`hit:FindFirstAncestorWhichIsA(\"Model\")` returns the first Model ancestor of the touched part. BODY-driven slot items (#139) mount as FBX Models welded inside the vehicle Model — so a touched BODY part returns the BODY sub-model, not the registered vehicleModel. `pdata.vehicleModel == vehicle` always failed, CP never registered.

Replaced with `_findPlayerByTouch(hit)` that walks ALL Model ancestors and checks each against a {vehicleModel → player} map built once per touch.

### English CP labels (per request)

- Map builders: "체크포인트 N" → "CP N"
- Pass toast: "체크포인트 N 통과! ✓" → "CP N PASSED ✓"
- Intro overlay body: English

(Title "🏁 레이스 시작!" left in Korean — only CP references were called out as needing English.)

> Note on farming-phase visibility: MapManager already toggles `RaceTrack` subfolder Transparency + BillboardGui.Enabled during FARMING. All new CP arch / beacon / label parts are inside `trackSub`, so they're auto-hidden during farming. If the user still sees them, that's a separate bug to chase.

## Test plan
- [ ] Drive through CP1 → HUD updates + "CP 1 PASSED ✓" toast
- [ ] Drive through CP2 (after CP1) → same for CP2
- [ ] Drive past finish line without CP1+CP2 → ignored (server log warns)
- [ ] Verify CP labels show "CP 1" / "CP 2" in English