### PR TITLE
fix(ocean): unblock CP1 + stop grass blades on water (#170)

### DIFF
--- a/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/OceanMapBuilder.server.lua
@@ -318,7 +318,12 @@ end
 -- Inside the S2 arc, X≈+90 Z≈0; island prevents straight-line shortcut.
 
 local function _buildPalmIsland(root)
-	local cx, cz = 90, 0  -- inside the arc's east bulge
+	-- Shifted west from cx=90 to cx=40 so the island's east edge (45) sits
+	-- well inside the chord but doesn't intrude into the S2 arc nodes.
+	-- The arc passes through N4(140, 100); with cx=90 (east edge 145) the
+	-- arc clipped 5 stud into the island and boats couldn't reach CP1 at N5.
+	-- New east edge: 40 + 110/2 = 95, giving N4 a 45-stud clearance.
+	local cx, cz = 40, 0
 	_part(root, {
 		Name = "Palm_IslandBase", Size = Vector3.new(110, 8, 220),
 		Position = Vector3.new(cx, WATER_Y - 2, cz),
@@ -536,10 +541,14 @@ local function _buildFarmIsland(root)
 		Position = Vector3.new(cx, WATER_Y - 1, cz),
 		Color = C.SAND, Material = MAT.SAND,
 	})
+	-- SmoothPlastic (not Grass) — Material.Grass renders blades that survive
+	-- MapManager's Transparency=1 hide, so during racing the FarmGrass blades
+	-- were still bleeding through onto the channel water, making OCEAN look
+	-- like a swamp. Same workaround applied to PalmIslandTop earlier.
 	_part(root, {
 		Name = "FarmGrass", Size = Vector3.new(160, 1, 230),
 		Position = Vector3.new(cx, WATER_Y + 2.5, cz),
-		Color = C.GRASS, Material = MAT.GRASS,
+		Color = C.GRASS, Material = Enum.Material.SmoothPlastic,
 	})
 
 	local cols = { -60, -30, 0, 30, 60 }

--- a/roblox/ServerScriptService/MapBuilders/TerrainPainter.server.lua
+++ b/roblox/ServerScriptService/MapBuilders/TerrainPainter.server.lua
@@ -87,9 +87,13 @@ local function _paintOcean()
 	-- Water volume
 	_fillBox(0, -8, 0, 600, 16, 1600, TM.Water)
 
-	-- Farm island sand base
-	_fillBox(0, -4, 375, 170, 8, 270, TM.Sand)
-	_fillBox(0, 2, 375, 140, 2, 230, TM.Grass)
+	-- Farm island sand base (matches the FarmIsland part at cx=0, cz=850).
+	-- Earlier this was painted at Z=375 — completely outside the farm island —
+	-- and the Grass layer at the water surface was rendering blades on the
+	-- racing channel water (CP1 sits at Z=0). Terrain blades survive
+	-- MapManager's part visibility toggle, so playtest saw "swamp grass"
+	-- on the OCEAN water during racing.
+	_fillBox(0, -4, 850, 200, 8, 280, TM.Sand)
 
 	-- Coral reef decorations (shallow rocks near track)
 	local rng = Random.new(55)
@@ -100,10 +104,10 @@ local function _paintOcean()
 		_fillSphere(rx, -12, rz, rr, TM.Rock)
 	end
 
-	-- Sandy shallows near island
+	-- Sandy shallows near the farm island, NOT in the racing channel.
 	for _ = 1, 15 do
 		local sx = rng:NextNumber(-120, 120)
-		local sz = rng:NextNumber(200, 550)
+		local sz = rng:NextNumber(700, 1000)
 		_fillSphere(sx, -5, sz, rng:NextNumber(5, 12), TM.Sand)
 	end
 


### PR DESCRIPTION
See #170. Palm island moved west (cx=90→40) so the channel arc passes east of it. TerrainPainter's orphan Grass block at z=375 (mislabeled 'Farm island', actual farm is at z=850) removed and moved to z=850. FarmGrass material Grass→SmoothPlastic.

Closes #170.